### PR TITLE
fix: clean up ghost canvas after legacy export to prevent LiteGraph e…

### DIFF
--- a/ops/adr/0005-ghost-canvas-cleanup.md
+++ b/ops/adr/0005-ghost-canvas-cleanup.md
@@ -1,0 +1,29 @@
+## 0005: 👻 ゴーストCanvasリークの修正 (Ghost Canvas Cleanup)
+
+### 状況
+
+- ComfyUI (LiteGraph) 環境でエクスポートを実行すると、一時的な Canvas インスタンスが `app.graph` にバインドされたまま残ってしまう。
+- これにより、エクスポート完了後も LiteGraph の描画ループが非表示の Canvas（parentNode が null の状態）を参照し続け、`TypeError: this.canvas.parentNode was null` エラーを引き起こしていた。
+- また、古いエクスポート用 Canvas がメモリ上に残り続け、イベントリスナーも解除されないため、ブラウザの動作が重くなる原因となっていた。
+
+### 決定
+
+- `captureLegacy` (legacy_capture.js) および `safeCleanup` (render_graph_offscreen.js) において、エクスポート完了時に確実に Canvas を解除する処理を追加する。
+- 処理を `try...finally` ブロックで囲み、以下のメソッドを確実に呼び出す：
+  1. `offscreen.stopRendering()`: 描画ループの停止
+  2. `offscreen.setCanvas(null)`: LiteGraph 内部での Canvas 参照の解除
+  3. `offscreen.unbind_events()`: イベントリスナーの解除
+
+### 理由
+
+- エラーの直接的な原因は DOM から切り離された Canvas に対して LiteGraph が `checkPanels` 等を実行しようとすることにある。
+- `setCanvas(null)` および `unbind_events()` を呼び出すことで、LiteGraph の管理下から Canvas を安全に切り離すことができる。
+
+### 影響
+
+- エクスポート後の安定性が向上し、コンソールエラーが解消される。
+- UI 操作のパフォーマンス低下が防止される。
+
+### 補足
+
+- 修正は `web/js/core/backends/legacy_capture.js` および `web/js/export/render_graph_offscreen.js` の両方に適用する。

--- a/web/js/core/backends/legacy_capture.js
+++ b/web/js/core/backends/legacy_capture.js
@@ -1102,88 +1102,92 @@ export async function captureLegacy(options = {}) {
   offscreen.canvas = exportCanvas;
   offscreen.ctx = exportCtx;
 
-  copyRenderSettings(uiCanvas, offscreen);
-  forceExportQuality(offscreen);
-  const mode = applyBackgroundMode(offscreen, options);
-  offscreen.render_canvas_border = false;
-  if (typeof offscreen.resize === "function") {
-    offscreen.resize(width, height);
-    debugLog?.("offscreen.resize", { width, height });
-  }
-  ensureBgCanvas(offscreen, width, height);
-  configureTransform(offscreen, bounds, width, height, scale, debugLog);
+  try {
+    copyRenderSettings(uiCanvas, offscreen);
+    forceExportQuality(offscreen);
+    const mode = applyBackgroundMode(offscreen, options);
+    offscreen.render_canvas_border = false;
+    if (typeof offscreen.resize === "function") {
+      offscreen.resize(width, height);
+      debugLog?.("offscreen.resize", { width, height });
+    }
+    ensureBgCanvas(offscreen, width, height);
+    configureTransform(offscreen, bounds, width, height, scale, debugLog);
 
-  applyBackgroundFill(
-    mode,
-    width,
-    height,
-    exportCtx,
-    offscreen.bgctx,
-    options?.solidColor
-  );
-
-  if (debug) {
-    console.log("[CWIE][Legacy] export:bounds", bounds);
-    console.log("[CWIE][Legacy] export:canvas", {
-      width: exportCanvas.width,
-      height: exportCanvas.height,
-      ctxCanvasIsExport: offscreen.ctx?.canvas === exportCanvas,
-    });
-    console.log(
-      "[CWIE][Legacy] export:bgcanvas",
-      offscreen.bgcanvas
-        ? {
-          width: offscreen.bgcanvas.width,
-          height: offscreen.bgcanvas.height,
-          alpha: offscreen.bgctx?.getContextAttributes?.()?.alpha,
-        }
-        : null
+    applyBackgroundFill(
+      mode,
+      width,
+      height,
+      exportCtx,
+      offscreen.bgctx,
+      options?.solidColor
     );
-    console.log("[CWIE][Legacy] export:mode", mode);
-    debugLog?.("render.flags", {
-      render_background: offscreen.render_background,
-      clear_background: offscreen.clear_background,
-      clear_background_color: offscreen.clear_background_color,
-      show_grid: offscreen.show_grid,
-      bgcolor: offscreen.bgcolor,
-      background_color: offscreen.background_color,
-      background_image: offscreen.background_image,
+
+    if (debug) {
+      console.log("[CWIE][Legacy] export:bounds", bounds);
+      console.log("[CWIE][Legacy] export:canvas", {
+        width: exportCanvas.width,
+        height: exportCanvas.height,
+        ctxCanvasIsExport: offscreen.ctx?.canvas === exportCanvas,
+      });
+      console.log(
+        "[CWIE][Legacy] export:bgcanvas",
+        offscreen.bgcanvas
+          ? {
+            width: offscreen.bgcanvas.width,
+            height: offscreen.bgcanvas.height,
+            alpha: offscreen.bgctx?.getContextAttributes?.()?.alpha,
+          }
+          : null
+      );
+      console.log("[CWIE][Legacy] export:mode", mode);
+      debugLog?.("render.flags", {
+        render_background: offscreen.render_background,
+        clear_background: offscreen.clear_background,
+        clear_background_color: offscreen.clear_background_color,
+        show_grid: offscreen.show_grid,
+        bgcolor: offscreen.bgcolor,
+        background_color: offscreen.background_color,
+        background_image: offscreen.background_image,
+      });
+      debugLog?.("ui.ds", {
+        scale: uiCanvas.ds?.scale,
+        offset: Array.isArray(uiCanvas.ds?.offset) ? [...uiCanvas.ds.offset] : null,
+      });
+      debugLog?.("ui.flags", {
+        render_background: uiCanvas.render_background,
+        clear_background: uiCanvas.clear_background,
+        show_grid: uiCanvas.show_grid,
+        bgcolor: uiCanvas.bgcolor,
+        background_color: uiCanvas.background_color,
+      });
+      logDomMedia(debugLog, uiCanvas);
+    }
+
+    await drawOffscreen(offscreen, {
+      mode,
+      width,
+      height,
+      exportCtx,
+      bgctx: offscreen.bgctx,
+      solidColor: options?.solidColor,
+      resetTransform: () => configureTransform(offscreen, bounds, width, height, scale, debugLog),
     });
-    debugLog?.("ui.ds", {
-      scale: uiCanvas.ds?.scale,
-      offset: Array.isArray(uiCanvas.ds?.offset) ? [...uiCanvas.ds.offset] : null,
-    });
-    debugLog?.("ui.flags", {
-      render_background: uiCanvas.render_background,
-      clear_background: uiCanvas.clear_background,
-      show_grid: uiCanvas.show_grid,
-      bgcolor: uiCanvas.bgcolor,
-      background_color: uiCanvas.background_color,
-    });
-    logDomMedia(debugLog, uiCanvas);
+    drawImageOverlays({ exportCtx, uiCanvas, bounds, scale, debugLog });
+    drawVideoOverlays({ exportCtx, uiCanvas, bounds, scale, nodeRects, debugLog });
+    drawTextOverlays({ exportCtx, uiCanvas, graph, bounds, scale, nodeRects, debugLog });
+
+    const blob = await toBlobAsync(exportCanvas, mime);
+    return {
+      type: "raster",
+      mime,
+      blob,
+      width,
+      height,
+    };
+  } finally {
+    try { if (typeof offscreen.stopRendering === "function") offscreen.stopRendering(); } catch (_) {}
+    try { if (typeof offscreen.setCanvas === "function") offscreen.setCanvas(null); } catch (_) {}
+    try { if (typeof offscreen.unbind_events === "function") offscreen.unbind_events(); } catch (_) {}
   }
-
-  await drawOffscreen(offscreen, {
-    mode,
-    width,
-    height,
-    exportCtx,
-    bgctx: offscreen.bgctx,
-    solidColor: options?.solidColor,
-    resetTransform: () => configureTransform(offscreen, bounds, width, height, scale, debugLog),
-  });
-  drawImageOverlays({ exportCtx, uiCanvas, bounds, scale, debugLog });
-  drawVideoOverlays({ exportCtx, uiCanvas, bounds, scale, nodeRects, debugLog });
-  drawTextOverlays({ exportCtx, uiCanvas, graph, bounds, scale, nodeRects, debugLog });
-
-
-
-  const blob = await toBlobAsync(exportCanvas, mime);
-  return {
-    type: "raster",
-    mime,
-    blob,
-    width,
-    height,
-  };
 }

--- a/web/js/export/render_graph_offscreen.js
+++ b/web/js/export/render_graph_offscreen.js
@@ -971,6 +971,8 @@ export async function renderGraphOffscreen(workflowJson, options = {}) {
   offscreen._cwieTileOffsetX = tileRect?.x || 0;
   offscreen._cwieTileOffsetY = tileRect?.y || 0;
 
+  let _exportOk = false;
+  try {
   // [CWIE] v3: Resize is disabled by default to prevent double-scaling.
   // Explicitly enabled only if options.enableOffscreenResize is set.
   if (offscreen.resize && options.enableOffscreenResize) {
@@ -1224,6 +1226,7 @@ export async function renderGraphOffscreen(workflowJson, options = {}) {
   }
 
   perfLog?.("done");
+  _exportOk = true;
   return {
     canvas: outputCanvas,
     ctx: outputCtx,
@@ -1237,6 +1240,11 @@ export async function renderGraphOffscreen(workflowJson, options = {}) {
       safeCleanup(offscreen, graph);
     },
   };
+  } finally {
+    if (!_exportOk) {
+      safeCleanup(offscreen, graph);
+    }
+  }
 }
 
 // --- Helper Classes & Functions ---

--- a/web/js/export/render_graph_offscreen.js
+++ b/web/js/export/render_graph_offscreen.js
@@ -621,6 +621,20 @@ function safeCleanup(offscreen, graph) {
     // ignore
   }
   try {
+    if (typeof offscreen?.setCanvas === "function") {
+      offscreen.setCanvas(null);
+    }
+  } catch (_) {
+    // ignore
+  }
+  try {
+    if (typeof offscreen?.unbind_events === "function") {
+      offscreen.unbind_events();
+    }
+  } catch (_) {
+    // ignore
+  }
+  try {
     if (typeof offscreen?.clear === "function") {
       offscreen.clear();
     }


### PR DESCRIPTION
…rrors

After export, the offscreen LGraphCanvas instance remained bound to app.graph, causing the rendering loop to reference a detached canvas (parentNode null) and throwing TypeError. Wrap captureLegacy in try...finally to always call stopRendering/setCanvas(null)/unbind_events. Also add the same two calls to safeCleanup so renderGraphOffscreen benefits as well.