### PR TITLE
[codex] Add Node 2 compositor capture support

### DIFF
--- a/ops/spikes/001-node2-compositor-capture.md
+++ b/ops/spikes/001-node2-compositor-capture.md
@@ -8,8 +8,11 @@ This spike reviews whether ComfyUI Node 2.0 can be exported as a workflow image
 from inside the normal browser extension, without trying to reproduce the
 Classic LiteGraph offscreen renderer.
 
-This is not a user-facing implementation. The goal is to prove or reject the
-browser-compositor capture path before adding any Node 2.0 export UI.
+Historical note: this spike was not originally a user-facing implementation.
+The initial spike goal was to prove or reject the browser-compositor capture
+path before adding any Node 2.0 export UI. The current PR now includes the
+Node 2.0 export UI path, so this note describes the starting intent rather than
+the current implementation status.
 
 ## Current Findings
 

--- a/ops/spikes/001-node2-compositor-capture.md
+++ b/ops/spikes/001-node2-compositor-capture.md
@@ -88,8 +88,14 @@ dialog behavior remain on the existing legacy path.
 Proceed only if `captureFrame({ target: "commonRoot" })` proves that the current
 browser can capture a readable graph-view frame including Vue nodes and links.
 
-If common-root capture works, the next implementation step is a Node 2.0 backend
-behind feature detection that initially supports:
+The local/user browser probe passed after the capture order was adjusted to
+attach and start the hidden video before applying `restrictTo()`. On this
+browser, `requestVideoFrameCallback()` stalled after restriction, but the video
+already had current frame data, so the implementation falls back to
+`requestAnimationFrame()` before drawing to canvas.
+
+The first implementation step is a Node 2.0 backend behind feature detection
+that initially supports:
 
 - PNG/WebP of the visible graph viewport.
 - Solid or UI background only.
@@ -100,4 +106,3 @@ behind feature detection that initially supports:
 If common-root capture fails, do not spend more time on browser-only WYSIWYG
 Node 2.0 export. The more honest route would be an external screenshot backend
 or a future ComfyUI-provided renderer/export API.
-

--- a/ops/spikes/001-node2-compositor-capture.md
+++ b/ops/spikes/001-node2-compositor-capture.md
@@ -1,0 +1,103 @@
+# Node 2.0 Compositor Capture Spike
+
+Date: 2026-06-07
+
+## Scope
+
+This spike reviews whether ComfyUI Node 2.0 can be exported as a workflow image
+from inside the normal browser extension, without trying to reproduce the
+Classic LiteGraph offscreen renderer.
+
+This is not a user-facing implementation. The goal is to prove or reject the
+browser-compositor capture path before adding any Node 2.0 export UI.
+
+## Current Findings
+
+- `ops/adr/0011...` is not present in this repository. This review used the
+  current README, existing ADRs, and the installed ComfyUI frontend package.
+- Local ComfyUI checked during the spike: `0.24.0`.
+- Local frontend package checked during the spike:
+  `comfyui_frontend_package 1.45.15`.
+- Node 2.0 renders as a browser composition of the main graph canvas, Vue node
+  DOM inside `TransformPane`, and a separate link overlay canvas.
+- In the installed frontend sourcemap, `GraphCanvas.vue` places:
+  - `#graph-canvas`
+  - `[data-testid="transform-pane"]`
+  - `LinkOverlayCanvas`
+  as sibling layers inside the graph view.
+- `TransformPane.vue` mirrors LiteGraph camera state with CSS transforms:
+  `scale3d(camera.z, camera.z, 1) translate3d(camera.x, camera.y, 0)`.
+- The Classic offscreen-LiteGraph strategy is therefore not a faithful Node 2.0
+  strategy. It can miss Vue DOM nodes, transformed node content, and overlay
+  link state.
+
+## Browser API Assessment
+
+The most plausible browser-only WYSIWYG route is:
+
+1. Ask the user to share the current tab with `getDisplayMedia()`.
+2. Restrict the resulting tab-capture video track to the graph-view root with
+   Element Capture (`RestrictionTarget` / `restrictTo`) when available.
+3. Fall back to Region Capture (`CropTarget` / `cropTo`) for rectangular graph
+   root cropping when Element Capture is unavailable.
+4. Draw a stable video frame into a canvas, then encode the result.
+
+This is a reasonable compromise, but it is not equivalent to Classic export:
+
+- It requires user browser capture permission.
+- It cannot force the user to choose the current tab; it can only hint and then
+  detect likely self-capture.
+- Region Capture crops by rectangle and can include occluding pixels.
+- Captured video frames do not preserve alpha, so transparent background is not
+  a first-pass Node 2.0 feature.
+- Large graph export needs camera movement and stitched captures; this depends
+  on frame-settling behavior and must be tested in the actual ComfyUI frontend.
+
+Alternatives considered:
+
+- Serializing Vue/DOM into SVG or foreignObject repeats the legacy fragility and
+  may fetch or taint external media.
+- Reusing minimap or thumbnails is not WYSIWYG enough for node screenshots.
+- Directly mounting ComfyUI Vue components offscreen is too coupled to private
+  frontend internals.
+- Electron/CDP/Playwright screenshots could be more faithful, but that is no
+  longer a normal custom-node browser extension and belongs in a separate tool.
+
+## Implemented Probe
+
+`web/js/main.js` exposes a lazy debug-only API:
+
+```js
+await window.__cwie__.node2Spike.inspect()
+await window.__cwie__.node2Spike.captureFrame({ target: "commonRoot" })
+await window.__cwie__.node2Spike.tileProbe({ tiles: 2 })
+```
+
+Targets accepted by `captureFrame()`:
+
+- `commonRoot`: graph canvas, Vue transform pane, and link overlay together.
+- `transformPane`: Vue node DOM only.
+- `linkOverlayCanvas`: Node 2.0 link canvas only.
+- `graphCanvas`: the base graph canvas only.
+
+The probe is only loaded when those methods are called. Normal Classic menu and
+dialog behavior remain on the existing legacy path.
+
+## Recommendation
+
+Proceed only if `captureFrame({ target: "commonRoot" })` proves that the current
+browser can capture a readable graph-view frame including Vue nodes and links.
+
+If common-root capture works, the next implementation step is a Node 2.0 backend
+behind feature detection that initially supports:
+
+- PNG/WebP of the visible graph viewport.
+- Solid or UI background only.
+- Workflow metadata embedding for PNG.
+- Clear unsupported messaging for transparent background, exact Classic-style
+  selection cropping, and huge tiled export until separately proven.
+
+If common-root capture fails, do not spend more time on browser-only WYSIWYG
+Node 2.0 export. The more honest route would be an external screenshot backend
+or a future ComfyUI-provided renderer/export API.
+

--- a/web/css/dialog.css
+++ b/web/css/dialog.css
@@ -115,6 +115,14 @@
   display: flex;
 }
 
+.cwie-preview-frame.is-message .cwie-preview-loading {
+  display: flex;
+}
+
+.cwie-preview-frame.is-message .cwie-preview-loading-icon {
+  display: none;
+}
+
 .cwie-preview-image:not([src]),
 .cwie-preview-image[src=""],
 .cwie-preview-canvas:not([width]),

--- a/web/css/dialog.css
+++ b/web/css/dialog.css
@@ -202,7 +202,7 @@
   grid-template-columns: 8.75rem 1fr;
   gap: 0.75rem;
   align-items: center;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.55rem;
 }
 
 .cwie-row.is-hidden {
@@ -213,6 +213,24 @@
   font-size: 0.75rem;
   color: var(--fg-color, #e5e5e5);
   opacity: 0.7;
+}
+
+.cwie-row.is-node2-disabled {
+  opacity: 0.52;
+}
+
+.cwie-row.is-node2-disabled label {
+  color: rgba(229, 229, 229, 0.48);
+  opacity: 1;
+}
+
+.cwie-row.is-node2-disabled > :not(.cwie-row-label) {
+  filter: grayscale(0.65);
+  opacity: 0.58;
+}
+
+.cwie-row.is-node2-disabled .cwie-help {
+  opacity: 0.35;
 }
 
 .cwie-row-label {
@@ -298,8 +316,9 @@
   color: inherit;
   border: none;
   border-radius: 0.35rem;
-  padding: 0.4rem 0.6rem;
-  min-height: 2rem;
+  padding: 0.32rem 0.55rem;
+  min-height: 1.75rem;
+  font-size: 0.75rem;
   line-height: 1.2;
 }
 
@@ -334,8 +353,9 @@
   color: inherit;
   border: none;
   border-radius: 0.35rem;
-  padding: 0.4rem 0.6rem;
-  min-height: 2rem;
+  padding: 0.32rem 0.55rem;
+  min-height: 1.75rem;
+  font-size: 0.75rem;
   line-height: 1.2;
   cursor: pointer;
   display: flex;
@@ -370,6 +390,7 @@
   gap: 0.5rem;
   padding: 0.35rem 0.5rem;
   border-radius: 0.3rem;
+  font-size: 0.75rem;
   cursor: pointer;
   color: inherit;
 }
@@ -514,6 +535,42 @@
   opacity: 0.6;
   line-height: 1.4;
   margin-bottom: 0.25rem;
+}
+
+.cwie-backend-note {
+  border-radius: 0.45rem;
+  padding: 0.65rem 0.75rem;
+  margin: 0 0 0.85rem 0;
+  background: rgba(74, 144, 226, 0.1);
+  border: 1px solid rgba(74, 144, 226, 0.32);
+  color: rgba(229, 229, 229, 0.9);
+}
+
+.cwie-backend-note-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+
+.cwie-backend-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.15rem;
+  padding: 0.1rem 0.42rem;
+  border-radius: 999px;
+  background: rgba(74, 144, 226, 0.22);
+  color: rgba(229, 229, 229, 0.96);
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+
+.cwie-backend-note-body {
+  margin-top: 0.4rem;
+  font-size: 0.7rem;
+  line-height: 1.45;
+  color: rgba(229, 229, 229, 0.68);
 }
 
 .cwie-advanced {

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -119,6 +119,10 @@ function ensureSpikeStyle() {
     html.cwie-node2-capturing .cwie-dialog-backdrop {
       visibility: hidden !important;
     }
+
+    html.cwie-node2-capturing #graph-canvas-container > :not(#graph-canvas):not([data-testid="transform-pane"]):not(canvas:not([id])) {
+      visibility: hidden !important;
+    }
   `;
   document.head.appendChild(style);
 }
@@ -167,13 +171,13 @@ async function waitVideoMetadata(video, log) {
   }), "hidden video metadata");
 }
 
-async function waitVideoFrame(video, count = 2, log) {
+async function waitVideoFrame(video, count = 2, log, timeoutMs = 3000) {
   for (let i = 0; i < count; i += 1) {
     if (typeof video.requestVideoFrameCallback === "function") {
       try {
         await withTimeout(new Promise((resolve) => {
           video.requestVideoFrameCallback(() => resolve());
-        }), `video frame ${i + 1}`);
+        }), `video frame ${i + 1}`, timeoutMs);
       } catch (error) {
         if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || !video.videoWidth || !video.videoHeight) {
           throw error;
@@ -319,9 +323,13 @@ async function captureFrameFromStream(stream, target, targetName, captureHandle,
       log,
     });
     logStep(log, "target.apply", report.restriction);
-    await waitVideoFrame(video, 2, log);
+    const frameCount = Math.max(1, Number(options.frameCount) || 2);
+    const frameTimeoutMs = Math.max(50, Number(options.frameTimeoutMs) || 3000);
+    await waitVideoFrame(video, frameCount, log, frameTimeoutMs);
     const { canvas, ctx, width, height } = drawVideoToCanvas(video);
-    const probe = await canvasProbe(canvas, ctx, width, height);
+    const probe = options.probe === false
+      ? { blobOk: true, blobType: null, blobSize: 0, probed: false }
+      : await canvasProbe(canvas, ctx, width, height);
     report.frame = {
       width,
       height,
@@ -465,6 +473,9 @@ export async function captureNode2(options = {}) {
     ...options,
     target: options.target || "commonRoot",
     includeCanvas: true,
+    frameCount: 1,
+    frameTimeoutMs: 250,
+    probe: false,
     log: options.debug ? console.log : null,
   });
   if (report.error) {

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -209,6 +209,68 @@ function hideKnownComfyChrome() {
   };
 }
 
+function rectsIntersect(a, b) {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+function hideIntersectingChrome() {
+  const { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes } = getNode2Layers();
+  if (!root) return () => {};
+  const rootRect = root.getBoundingClientRect();
+  const keep = [root, graphCanvas, transformPane, linkOverlayCanvas].filter(Boolean);
+  const changed = [];
+  for (const el of asArray(document.body.querySelectorAll("*"))) {
+    if (!(el instanceof HTMLElement)) continue;
+    if (keep.includes(el)) continue;
+    if (vueNodes.some((node) => el === node || node.contains(el) || el.contains(node))) continue;
+    if (el.closest(".cwie-dialog") || el.closest(".cwie-backdrop")) continue;
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0 || !rectsIntersect(rect, rootRect)) continue;
+    const style = window.getComputedStyle(el);
+    const zIndex = Number.parseInt(style.zIndex, 10);
+    const positioned = style.position === "fixed" ||
+      style.position === "sticky" ||
+      style.position === "absolute" ||
+      Number.isFinite(zIndex);
+    if (!positioned) continue;
+    changed.push([el, el.style.visibility, el.style.pointerEvents]);
+    el.style.visibility = "hidden";
+    el.style.pointerEvents = "none";
+  }
+  return () => {
+    for (const [el, visibility, pointerEvents] of changed) {
+      el.style.visibility = visibility;
+      el.style.pointerEvents = pointerEvents;
+    }
+  };
+}
+
+function measureNode2DomCropRect(root, paddingPx) {
+  if (!root) return null;
+  const rootRect = root.getBoundingClientRect();
+  const nodeRects = asArray(root.querySelectorAll("[data-node-id]"))
+    .map((node) => node.getBoundingClientRect())
+    .filter((rect) => rect.width > 0 && rect.height > 0 && rectsIntersect(rect, rootRect));
+  if (!nodeRects.length) return null;
+  let left = Infinity;
+  let top = Infinity;
+  let right = -Infinity;
+  let bottom = -Infinity;
+  for (const rect of nodeRects) {
+    left = Math.min(left, rect.left - rootRect.left);
+    top = Math.min(top, rect.top - rootRect.top);
+    right = Math.max(right, rect.right - rootRect.left);
+    bottom = Math.max(bottom, rect.bottom - rootRect.top);
+  }
+  const pad = Math.max(8, Math.min(128, Number(paddingPx) || 56));
+  return {
+    left: Math.max(0, left - pad),
+    top: Math.max(0, top - pad),
+    right: Math.min(rootRect.width, right + pad),
+    bottom: Math.min(rootRect.height, bottom + pad),
+  };
+}
+
 function stopStream(stream) {
   for (const track of stream?.getTracks?.() || []) {
     track.stop();
@@ -499,6 +561,7 @@ export async function runNode2CaptureFrameSpike(options = {}) {
   document.documentElement.classList.add("cwie-node2-capturing");
   const restoreHiddenChrome = hideNode2CaptureChrome();
   const restoreKnownChrome = hideKnownComfyChrome();
+  const restoreIntersectingChrome = hideIntersectingChrome();
 
   let stream = null;
   try {
@@ -515,6 +578,7 @@ export async function runNode2CaptureFrameSpike(options = {}) {
     stopStream(stream);
     restoreHiddenChrome();
     restoreKnownChrome();
+    restoreIntersectingChrome();
     document.documentElement.classList.remove("cwie-node2-capturing");
   }
 }
@@ -568,9 +632,10 @@ async function withFitNode2View(options, fn) {
       width: rect.width,
       height: rect.height,
     },
+    cropRectCss: measureNode2DomCropRect(root, options.cropPaddingPx),
     scale,
     offset: [ds.offset[0], ds.offset[1]],
-    cropPaddingPx: Math.max(8, Math.min(64, Number(options.cropPaddingPx) || 24)),
+    cropPaddingPx: Math.max(8, Math.min(128, Number(options.cropPaddingPx) || 56)),
   };
   try {
     return await fn(fitInfo);
@@ -585,13 +650,13 @@ async function withFitNode2View(options, fn) {
 
 function cropNode2CanvasToFit(canvas, fitInfo) {
   if (!canvas || !fitInfo?.bbox || !fitInfo?.rootRect) return canvas;
-  const { bbox, scale, offset, rootRect, cropPaddingPx } = fitInfo;
+  const { bbox, scale, offset, rootRect, cropPaddingPx, cropRectCss } = fitInfo;
   const ratioX = canvas.width / Math.max(1, rootRect.width);
   const ratioY = canvas.height / Math.max(1, rootRect.height);
-  const leftCss = (bbox.minX + offset[0]) * scale - cropPaddingPx;
-  const topCss = (bbox.minY + offset[1]) * scale - cropPaddingPx;
-  const rightCss = (bbox.maxX + offset[0]) * scale + cropPaddingPx;
-  const bottomCss = (bbox.maxY + offset[1]) * scale + cropPaddingPx;
+  const leftCss = cropRectCss?.left ?? ((bbox.minX + offset[0]) * scale - cropPaddingPx);
+  const topCss = cropRectCss?.top ?? ((bbox.minY + offset[1]) * scale - cropPaddingPx);
+  const rightCss = cropRectCss?.right ?? ((bbox.maxX + offset[0]) * scale + cropPaddingPx);
+  const bottomCss = cropRectCss?.bottom ?? ((bbox.maxY + offset[1]) * scale + cropPaddingPx);
   const sx = Math.max(0, Math.floor(leftCss * ratioX));
   const sy = Math.max(0, Math.floor(topCss * ratioY));
   const ex = Math.min(canvas.width, Math.ceil(rightCss * ratioX));

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -765,6 +765,33 @@ function cropNode2CanvasToFit(canvas, fitInfo) {
   const ey = Math.min(canvas.height, Math.ceil(bottomCss * ratioY));
   const width = Math.max(1, ex - sx);
   const height = Math.max(1, ey - sy);
+  fitInfo.cropGeometry = {
+    sourceCanvas: {
+      width: canvas.width,
+      height: canvas.height,
+    },
+    rootRect,
+    ratio: {
+      x: ratioX,
+      y: ratioY,
+    },
+    css: {
+      left: leftCss,
+      top: topCss,
+      right: rightCss,
+      bottom: bottomCss,
+      width: rightCss - leftCss,
+      height: bottomCss - topCss,
+    },
+    px: {
+      sx,
+      sy,
+      ex,
+      ey,
+      width,
+      height,
+    },
+  };
   if (width >= canvas.width && height >= canvas.height) {
     return canvas;
   }
@@ -839,6 +866,7 @@ export async function captureNode2(options = {}) {
         croppedWidth: captured.canvas.width,
         croppedHeight: captured.canvas.height,
         cropRectCss: fitInfo.cropRectCss,
+        cropGeometry: fitInfo.cropGeometry,
         bbox: fitInfo.bbox,
         metricsAfterFit: fitInfo.metricsAfterFit,
       });

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -216,6 +216,16 @@ function rectsIntersect(a, b) {
   return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
 }
 
+function isVisibleElement(el) {
+  if (!(el instanceof Element)) return false;
+  const style = window.getComputedStyle(el);
+  if (style.display === "none" || style.visibility === "hidden" || style.visibility === "collapse") {
+    return false;
+  }
+  const opacity = Number.parseFloat(style.opacity);
+  return !Number.isFinite(opacity) || opacity > 0.01;
+}
+
 function hideIntersectingChrome() {
   const { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes } = getNode2Layers();
   if (!root) return () => {};
@@ -248,18 +258,35 @@ function hideIntersectingChrome() {
   };
 }
 
-function measureNode2DomCropRect(root, paddingPx) {
+function collectNode2VisualRects(root) {
   if (!root) return null;
   const rootRect = root.getBoundingClientRect();
-  const nodeRects = asArray(root.querySelectorAll("[data-node-id]"))
-    .map((node) => node.getBoundingClientRect())
-    .filter((rect) => rect.width > 0 && rect.height > 0 && rectsIntersect(rect, rootRect));
-  if (!nodeRects.length) return null;
+  const rects = [];
+  for (const node of asArray(root.querySelectorAll("[data-node-id]"))) {
+    const candidates = [node, ...asArray(node.querySelectorAll("*"))];
+    for (const el of candidates) {
+      if (!isVisibleElement(el)) continue;
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 1 || rect.height <= 1 || !rectsIntersect(rect, rootRect)) continue;
+      const coversRoot =
+        rect.width >= rootRect.width * 0.92 ||
+        rect.height >= rootRect.height * 0.92;
+      if (coversRoot) continue;
+      rects.push(rect);
+    }
+  }
+  return { rootRect, rects };
+}
+
+function measureNode2DomCropRect(root, paddingPx) {
+  const measured = collectNode2VisualRects(root);
+  if (!measured?.rects?.length) return null;
+  const { rootRect, rects } = measured;
   let left = Infinity;
   let top = Infinity;
   let right = -Infinity;
   let bottom = -Infinity;
-  for (const rect of nodeRects) {
+  for (const rect of rects) {
     left = Math.min(left, rect.left - rootRect.left);
     top = Math.min(top, rect.top - rootRect.top);
     right = Math.max(right, rect.right - rootRect.left);
@@ -278,16 +305,14 @@ function measureNode2DomGraphBBox(root, ds) {
   if (!root || !ds || !Array.isArray(ds.offset)) return null;
   const scale = Number(ds.scale) || 1;
   if (!Number.isFinite(scale) || scale <= 0) return null;
-  const rootRect = root.getBoundingClientRect();
-  const nodeRects = asArray(root.querySelectorAll("[data-node-id]"))
-    .map((node) => node.getBoundingClientRect())
-    .filter((rect) => rect.width > 0 && rect.height > 0);
-  if (!nodeRects.length) return null;
+  const measured = collectNode2VisualRects(root);
+  if (!measured?.rects?.length) return null;
+  const { rootRect, rects } = measured;
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
-  for (const rect of nodeRects) {
+  for (const rect of rects) {
     const left = ((rect.left - rootRect.left) / scale) - ds.offset[0];
     const top = ((rect.top - rootRect.top) / scale) - ds.offset[1];
     const right = ((rect.right - rootRect.left) / scale) - ds.offset[0];
@@ -307,6 +332,7 @@ function measureNode2DomGraphBBox(root, ds) {
     maxY,
     width: Math.max(1, maxX - minX),
     height: Math.max(1, maxY - minY),
+    measuredRects: rects.length,
   };
 }
 

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -33,6 +33,39 @@ function describeElement(el) {
   };
 }
 
+function getViewportRect() {
+  const vv = window.visualViewport;
+  return {
+    left: vv?.offsetLeft || 0,
+    top: vv?.offsetTop || 0,
+    width: vv?.width || window.innerWidth || document.documentElement.clientWidth || 1,
+    height: vv?.height || window.innerHeight || document.documentElement.clientHeight || 1,
+  };
+}
+
+function getCapturableRootRect(root) {
+  const rootRect = root?.getBoundingClientRect?.();
+  if (!rootRect) return null;
+  const viewport = getViewportRect();
+  const left = Math.max(rootRect.left, viewport.left);
+  const top = Math.max(rootRect.top, viewport.top);
+  const right = Math.min(rootRect.right, viewport.left + viewport.width);
+  const bottom = Math.min(rootRect.bottom, viewport.top + viewport.height);
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: Math.max(1, right - left),
+    height: Math.max(1, bottom - top),
+    rootLeft: rootRect.left,
+    rootTop: rootRect.top,
+    rootWidth: rootRect.width,
+    rootHeight: rootRect.height,
+    viewport,
+  };
+}
+
 function getApiSupport() {
   const proto = typeof BrowserCaptureMediaStreamTrack !== "undefined"
     ? BrowserCaptureMediaStreamTrack.prototype
@@ -282,6 +315,7 @@ function measureNode2DomCropRect(root, paddingPx) {
   const measured = collectNode2VisualRects(root);
   if (!measured?.rects?.length) return null;
   const { rootRect, rects } = measured;
+  const captureRect = getCapturableRootRect(root) || rootRect;
   let left = Infinity;
   let top = Infinity;
   let right = -Infinity;
@@ -296,8 +330,8 @@ function measureNode2DomCropRect(root, paddingPx) {
   return {
     left: Math.max(0, left - pad),
     top: Math.max(0, top - pad),
-    right: Math.min(rootRect.width, right + pad),
-    bottom: Math.min(rootRect.height, bottom + pad),
+    right: Math.min(captureRect.width, right + pad),
+    bottom: Math.min(captureRect.height, bottom + pad),
   };
 }
 
@@ -706,7 +740,7 @@ async function withFitNode2View(options, fn) {
     offset: [ds.offset[0], ds.offset[1]],
     scale: ds.scale || 1,
   };
-  const rect = root.getBoundingClientRect();
+  const rect = getCapturableRootRect(root) || root.getBoundingClientRect();
   const paddingPx = Math.max(24, Math.min(96, Number(options.fitPaddingPx) || 64));
   const bbox = measureNode2DomGraphBBox(root, ds) || computeGraphBBox(graph, {
     padding: 0,
@@ -732,6 +766,10 @@ async function withFitNode2View(options, fn) {
     rootRect: {
       width: rect.width,
       height: rect.height,
+      left: rect.left,
+      top: rect.top,
+      rootLeft: rect.rootLeft ?? rect.left,
+      rootTop: rect.rootTop ?? rect.top,
     },
     cropRectCss: measureNode2DomCropRect(root, options.cropPaddingPx),
     scale,
@@ -753,16 +791,23 @@ async function withFitNode2View(options, fn) {
 function cropNode2CanvasToFit(canvas, fitInfo) {
   if (!canvas || !fitInfo?.bbox || !fitInfo?.rootRect) return canvas;
   const { bbox, scale, offset, rootRect, cropPaddingPx, cropRectCss } = fitInfo;
-  const ratioX = canvas.width / Math.max(1, rootRect.width);
-  const ratioY = canvas.height / Math.max(1, rootRect.height);
+  const viewport = getViewportRect();
+  const ratioX = canvas.width / Math.max(1, viewport.width);
+  const ratioY = canvas.height / Math.max(1, viewport.height);
   const leftCss = cropRectCss?.left ?? ((bbox.minX + offset[0]) * scale - cropPaddingPx);
   const topCss = cropRectCss?.top ?? ((bbox.minY + offset[1]) * scale - cropPaddingPx);
   const rightCss = cropRectCss?.right ?? ((bbox.maxX + offset[0]) * scale + cropPaddingPx);
   const bottomCss = cropRectCss?.bottom ?? ((bbox.maxY + offset[1]) * scale + cropPaddingPx);
-  const sx = Math.max(0, Math.floor(leftCss * ratioX));
-  const sy = Math.max(0, Math.floor(topCss * ratioY));
-  const ex = Math.min(canvas.width, Math.ceil(rightCss * ratioX));
-  const ey = Math.min(canvas.height, Math.ceil(bottomCss * ratioY));
+  const rootLeft = rootRect.rootLeft ?? rootRect.left ?? 0;
+  const rootTop = rootRect.rootTop ?? rootRect.top ?? 0;
+  const viewportLeftCss = rootLeft + leftCss - viewport.left;
+  const viewportTopCss = rootTop + topCss - viewport.top;
+  const viewportRightCss = rootLeft + rightCss - viewport.left;
+  const viewportBottomCss = rootTop + bottomCss - viewport.top;
+  const sx = Math.max(0, Math.floor(viewportLeftCss * ratioX));
+  const sy = Math.max(0, Math.floor(viewportTopCss * ratioY));
+  const ex = Math.min(canvas.width, Math.ceil(viewportRightCss * ratioX));
+  const ey = Math.min(canvas.height, Math.ceil(viewportBottomCss * ratioY));
   const width = Math.max(1, ex - sx);
   const height = Math.max(1, ey - sy);
   fitInfo.cropGeometry = {
@@ -771,6 +816,7 @@ function cropNode2CanvasToFit(canvas, fitInfo) {
       height: canvas.height,
     },
     rootRect,
+    viewport,
     ratio: {
       x: ratioX,
       y: ratioY,
@@ -782,6 +828,14 @@ function cropNode2CanvasToFit(canvas, fitInfo) {
       bottom: bottomCss,
       width: rightCss - leftCss,
       height: bottomCss - topCss,
+    },
+    viewportCss: {
+      left: viewportLeftCss,
+      top: viewportTopCss,
+      right: viewportRightCss,
+      bottom: viewportBottomCss,
+      width: viewportRightCss - viewportLeftCss,
+      height: viewportBottomCss - viewportTopCss,
     },
     px: {
       sx,

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -117,12 +117,29 @@ function ensureSpikeStyle() {
     html.cwie-node2-capturing .p-contextmenu,
     html.cwie-node2-capturing .litegraph.litecontextmenu,
     html.cwie-node2-capturing .cwie-backdrop,
-    html.cwie-node2-capturing .cwie-dialog-backdrop {
+    html.cwie-node2-capturing .cwie-dialog-backdrop,
+    html.cwie-node2-capturing #comfyui-body-top,
+    html.cwie-node2-capturing #comfyui-body-left,
+    html.cwie-node2-capturing #comfyui-body-right,
+    html.cwie-node2-capturing #comfyui-body-bottom,
+    html.cwie-node2-capturing [data-testid*="toolbar" i],
+    html.cwie-node2-capturing [data-testid*="menu" i],
+    html.cwie-node2-capturing [data-testid*="selection" i],
+    html.cwie-node2-capturing [class*="toolbar" i],
+    html.cwie-node2-capturing [class*="palette" i],
+    html.cwie-node2-capturing [class*="actionbar" i],
+    html.cwie-node2-capturing [class*="topbar" i] {
       visibility: hidden !important;
+      pointer-events: none !important;
     }
 
     html.cwie-node2-capturing #graph-canvas-container > :not(#graph-canvas):not([data-testid="transform-pane"]):not(canvas:not([id])) {
       visibility: hidden !important;
+    }
+
+    html.cwie-node2-capturing #graph-canvas-container,
+    html.cwie-node2-capturing #graph-canvas-container * {
+      cursor: none !important;
     }
   `;
   document.head.appendChild(style);
@@ -150,12 +167,44 @@ function hideNode2CaptureChrome() {
   };
   for (const el of asArray(root.querySelectorAll("*"))) {
     if (!(el instanceof HTMLElement) || shouldKeep(el)) continue;
-    changed.push([el, el.style.visibility]);
+    changed.push([el, el.style.visibility, el.style.pointerEvents]);
     el.style.visibility = "hidden";
+    el.style.pointerEvents = "none";
   }
   return () => {
-    for (const [el, visibility] of changed) {
+    for (const [el, visibility, pointerEvents] of changed) {
       el.style.visibility = visibility;
+      el.style.pointerEvents = pointerEvents;
+    }
+  };
+}
+
+function hideKnownComfyChrome() {
+  const selectors = [
+    "#comfyui-body-top",
+    "#comfyui-body-left",
+    "#comfyui-body-right",
+    "#comfyui-body-bottom",
+    '[data-testid*="toolbar" i]',
+    '[data-testid*="menu" i]',
+    '[data-testid*="selection" i]',
+    '[class*="toolbar" i]',
+    '[class*="palette" i]',
+    '[class*="actionbar" i]',
+    '[class*="topbar" i]',
+  ];
+  const changed = [];
+  for (const el of asArray(document.querySelectorAll(selectors.join(",")))) {
+    if (!(el instanceof HTMLElement)) continue;
+    if (el.closest("[data-node-id]")) continue;
+    changed.push([el, el.style.visibility, el.style.pointerEvents]);
+    el.style.visibility = "hidden";
+    el.style.pointerEvents = "none";
+  }
+  return () => {
+    for (const [el, visibility, pointerEvents] of changed) {
+      el.style.visibility = visibility;
+      el.style.pointerEvents = pointerEvents;
     }
   };
 }
@@ -310,7 +359,9 @@ async function requestDisplayMedia(log) {
     selfBrowserSurface: "include",
     surfaceSwitching: "exclude",
     audio: false,
-    video: true,
+    video: {
+      cursor: "never",
+    },
   };
   try {
     return await navigator.mediaDevices.getDisplayMedia(preferredOptions);
@@ -447,6 +498,7 @@ export async function runNode2CaptureFrameSpike(options = {}) {
   const captureHandle = await maybeSetCaptureHandle(log);
   document.documentElement.classList.add("cwie-node2-capturing");
   const restoreHiddenChrome = hideNode2CaptureChrome();
+  const restoreKnownChrome = hideKnownComfyChrome();
 
   let stream = null;
   try {
@@ -462,6 +514,7 @@ export async function runNode2CaptureFrameSpike(options = {}) {
   } finally {
     stopStream(stream);
     restoreHiddenChrome();
+    restoreKnownChrome();
     document.documentElement.classList.remove("cwie-node2-capturing");
   }
 }
@@ -475,14 +528,14 @@ async function waitForNode2CameraSettle(ms = 320) {
 
 async function withFitNode2View(options, fn) {
   if (options.fitView === false) {
-    return fn();
+    return fn(null);
   }
   const canvas = app?.canvas;
   const ds = canvas?.ds;
   const root = getNode2Layers().root;
   const graph = app?.graph || canvas?.graph;
   if (!canvas?.canvas || !ds || !Array.isArray(ds.offset) || !graph || !root) {
-    return fn();
+    return fn(null);
   }
 
   const original = {
@@ -502,13 +555,25 @@ async function withFitNode2View(options, fn) {
     0.05,
     Math.min(1.2, availableWidth / bbox.width, availableHeight / bbox.height)
   );
+  const visibleGraphWidth = rect.width / scale;
+  const visibleGraphHeight = rect.height / scale;
   ds.scale = scale;
-  ds.offset[0] = paddingPx / scale - bbox.minX;
-  ds.offset[1] = paddingPx / scale - bbox.minY;
+  ds.offset[0] = ((visibleGraphWidth - bbox.width) / 2) - bbox.minX;
+  ds.offset[1] = ((visibleGraphHeight - bbox.height) / 2) - bbox.minY;
   canvas.setDirty?.(true, true);
   await waitForNode2CameraSettle();
+  const fitInfo = {
+    bbox,
+    rootRect: {
+      width: rect.width,
+      height: rect.height,
+    },
+    scale,
+    offset: [ds.offset[0], ds.offset[1]],
+    cropPaddingPx: Math.max(8, Math.min(64, Number(options.cropPaddingPx) || 24)),
+  };
   try {
-    return await fn();
+    return await fn(fitInfo);
   } finally {
     ds.scale = original.scale;
     ds.offset[0] = original.offset[0];
@@ -516,6 +581,33 @@ async function withFitNode2View(options, fn) {
     canvas.setDirty?.(true, true);
     await waitForNode2CameraSettle(120);
   }
+}
+
+function cropNode2CanvasToFit(canvas, fitInfo) {
+  if (!canvas || !fitInfo?.bbox || !fitInfo?.rootRect) return canvas;
+  const { bbox, scale, offset, rootRect, cropPaddingPx } = fitInfo;
+  const ratioX = canvas.width / Math.max(1, rootRect.width);
+  const ratioY = canvas.height / Math.max(1, rootRect.height);
+  const leftCss = (bbox.minX + offset[0]) * scale - cropPaddingPx;
+  const topCss = (bbox.minY + offset[1]) * scale - cropPaddingPx;
+  const rightCss = (bbox.maxX + offset[0]) * scale + cropPaddingPx;
+  const bottomCss = (bbox.maxY + offset[1]) * scale + cropPaddingPx;
+  const sx = Math.max(0, Math.floor(leftCss * ratioX));
+  const sy = Math.max(0, Math.floor(topCss * ratioY));
+  const ex = Math.min(canvas.width, Math.ceil(rightCss * ratioX));
+  const ey = Math.min(canvas.height, Math.ceil(bottomCss * ratioY));
+  const width = Math.max(1, ex - sx);
+  const height = Math.max(1, ey - sy);
+  if (width >= canvas.width && height >= canvas.height) {
+    return canvas;
+  }
+  const out = document.createElement("canvas");
+  out.width = width;
+  out.height = height;
+  const ctx = out.getContext("2d", { alpha: true });
+  if (!ctx) return canvas;
+  ctx.drawImage(canvas, sx, sy, width, height, 0, 0, width, height);
+  return out;
 }
 
 function toBlob(canvas, mime) {
@@ -556,15 +648,27 @@ function collectNode2Warnings(options = {}) {
 export async function captureNode2(options = {}) {
   const format = String(options.format || "png").toLowerCase();
   const mime = format === "webp" ? "image/webp" : "image/png";
-  const report = await withFitNode2View(options, () => runNode2CaptureFrameSpike({
-    ...options,
-    target: options.target || "commonRoot",
-    includeCanvas: true,
-    frameCount: 1,
-    frameTimeoutMs: 250,
-    probe: false,
-    log: options.debug ? console.log : null,
-  }));
+  const report = await withFitNode2View(options, async (fitInfo) => {
+    const captured = await runNode2CaptureFrameSpike({
+      ...options,
+      target: options.target || "commonRoot",
+      includeCanvas: true,
+      frameCount: 1,
+      frameTimeoutMs: 250,
+      probe: false,
+      log: options.debug ? console.log : null,
+    });
+    if (captured.canvas && fitInfo) {
+      captured.canvas = cropNode2CanvasToFit(captured.canvas, fitInfo);
+      captured.frame = {
+        ...captured.frame,
+        croppedWidth: captured.canvas.width,
+        croppedHeight: captured.canvas.height,
+      };
+      captured.fit = fitInfo;
+    }
+    return captured;
+  });
   if (report.error) {
     throw new Error(`Node 2.0 capture failed: ${report.error.message || "unknown error"}`);
   }

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -1,4 +1,5 @@
 import { app } from "/scripts/app.js";
+import { computeGraphBBox } from "../../export/bbox.mjs";
 
 const SPIKE_STYLE_ID = "cwie-node2-spike-style";
 
@@ -125,6 +126,38 @@ function ensureSpikeStyle() {
     }
   `;
   document.head.appendChild(style);
+}
+
+function getNode2Layers() {
+  const graphCanvas = document.querySelector("#graph-canvas") || app?.canvas?.canvas || null;
+  const transformPane = document.querySelector('[data-testid="transform-pane"]');
+  const root = getGraphRootFromTransformPane(transformPane);
+  const siblingCanvases = root ? asArray(root.querySelectorAll("canvas")) : [];
+  const linkOverlayCanvas = siblingCanvases.find((canvas) => canvas !== graphCanvas && !canvas.id) || null;
+  const vueNodes = transformPane ? asArray(transformPane.querySelectorAll("[data-node-id]")) : [];
+  return { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes };
+}
+
+function hideNode2CaptureChrome() {
+  const { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes } = getNode2Layers();
+  if (!root) return () => {};
+  const keepTree = [graphCanvas, linkOverlayCanvas].filter(Boolean);
+  const changed = [];
+  const shouldKeep = (el) => {
+    if (!el || el === root || el === transformPane) return true;
+    if (keepTree.some((keep) => el === keep || keep.contains(el))) return true;
+    return vueNodes.some((node) => el === node || node.contains(el) || el.contains(node));
+  };
+  for (const el of asArray(root.querySelectorAll("*"))) {
+    if (!(el instanceof HTMLElement) || shouldKeep(el)) continue;
+    changed.push([el, el.style.visibility]);
+    el.style.visibility = "hidden";
+  }
+  return () => {
+    for (const [el, visibility] of changed) {
+      el.style.visibility = visibility;
+    }
+  };
 }
 
 function stopStream(stream) {
@@ -413,6 +446,7 @@ export async function runNode2CaptureFrameSpike(options = {}) {
   ensureSpikeStyle();
   const captureHandle = await maybeSetCaptureHandle(log);
   document.documentElement.classList.add("cwie-node2-capturing");
+  const restoreHiddenChrome = hideNode2CaptureChrome();
 
   let stream = null;
   try {
@@ -427,7 +461,60 @@ export async function runNode2CaptureFrameSpike(options = {}) {
     return report;
   } finally {
     stopStream(stream);
+    restoreHiddenChrome();
     document.documentElement.classList.remove("cwie-node2-capturing");
+  }
+}
+
+async function waitForNode2CameraSettle(ms = 320) {
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+async function withFitNode2View(options, fn) {
+  if (options.fitView === false) {
+    return fn();
+  }
+  const canvas = app?.canvas;
+  const ds = canvas?.ds;
+  const root = getNode2Layers().root;
+  const graph = app?.graph || canvas?.graph;
+  if (!canvas?.canvas || !ds || !Array.isArray(ds.offset) || !graph || !root) {
+    return fn();
+  }
+
+  const original = {
+    offset: [ds.offset[0], ds.offset[1]],
+    scale: ds.scale || 1,
+  };
+  const rect = root.getBoundingClientRect();
+  const paddingPx = Math.max(24, Math.min(96, Number(options.fitPaddingPx) || 64));
+  const bbox = computeGraphBBox(graph, {
+    padding: 0,
+    useBounding: true,
+    debug: Boolean(options.debug),
+  });
+  const availableWidth = Math.max(1, rect.width - paddingPx * 2);
+  const availableHeight = Math.max(1, rect.height - paddingPx * 2);
+  const scale = Math.max(
+    0.05,
+    Math.min(1.2, availableWidth / bbox.width, availableHeight / bbox.height)
+  );
+  ds.scale = scale;
+  ds.offset[0] = paddingPx / scale - bbox.minX;
+  ds.offset[1] = paddingPx / scale - bbox.minY;
+  canvas.setDirty?.(true, true);
+  await waitForNode2CameraSettle();
+  try {
+    return await fn();
+  } finally {
+    ds.scale = original.scale;
+    ds.offset[0] = original.offset[0];
+    ds.offset[1] = original.offset[1];
+    canvas.setDirty?.(true, true);
+    await waitForNode2CameraSettle(120);
   }
 }
 
@@ -469,7 +556,7 @@ function collectNode2Warnings(options = {}) {
 export async function captureNode2(options = {}) {
   const format = String(options.format || "png").toLowerCase();
   const mime = format === "webp" ? "image/webp" : "image/png";
-  const report = await runNode2CaptureFrameSpike({
+  const report = await withFitNode2View(options, () => runNode2CaptureFrameSpike({
     ...options,
     target: options.target || "commonRoot",
     includeCanvas: true,
@@ -477,7 +564,7 @@ export async function captureNode2(options = {}) {
     frameTimeoutMs: 250,
     probe: false,
     log: options.debug ? console.log : null,
-  });
+  }));
   if (report.error) {
     throw new Error(`Node 2.0 capture failed: ${report.error.message || "unknown error"}`);
   }

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -115,6 +115,7 @@ function ensureSpikeStyle() {
     html.cwie-node2-capturing .p-tooltip,
     html.cwie-node2-capturing .p-contextmenu,
     html.cwie-node2-capturing .litegraph.litecontextmenu,
+    html.cwie-node2-capturing .cwie-backdrop,
     html.cwie-node2-capturing .cwie-dialog-backdrop {
       visibility: hidden !important;
     }
@@ -327,6 +328,9 @@ async function captureFrameFromStream(stream, target, targetName, captureHandle,
       dpr: window.devicePixelRatio || 1,
       ...probe,
     };
+    if (options.includeCanvas) {
+      report.canvas = canvas;
+    }
     logStep(log, "frame.ok", report.frame);
     return report;
   } catch (error) {
@@ -393,7 +397,7 @@ async function applyTargetRestriction(track, target, { prefer = "restriction", l
 }
 
 export async function runNode2CaptureFrameSpike(options = {}) {
-  const log = options.log || console.log;
+  const log = Object.hasOwn(options, "log") ? options.log : console.log;
   const targetName = options.target || "commonRoot";
   const target = resolveTarget(targetName);
   const report = { startedAt: new Date().toISOString(), targetName, before: inspectNode2Targets() };
@@ -419,6 +423,72 @@ export async function runNode2CaptureFrameSpike(options = {}) {
   }
 }
 
+function toBlob(canvas, mime) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("Node 2.0 capture failed: canvas encoding returned no blob."));
+        return;
+      }
+      resolve(blob);
+    }, mime);
+  });
+}
+
+function collectNode2Warnings(options = {}) {
+  const warnings = [];
+  if (options.background === "transparent") {
+    warnings.push("node2:transparent_background_unsupported");
+  }
+  if (options.background === "solid") {
+    warnings.push("node2:solid_background_best_effort");
+  }
+  if (Number(options.padding) > 0) {
+    warnings.push("node2:padding_unsupported");
+  }
+  if (Boolean(options.scopeSelected)) {
+    warnings.push("node2:selection_crop_unsupported");
+  }
+  if (Number(options.nodeOpacity) < 100) {
+    warnings.push("node2:node_opacity_unsupported");
+  }
+  if (options.exceedMode === "tile") {
+    warnings.push("node2:tiled_export_unsupported");
+  }
+  return warnings;
+}
+
+export async function captureNode2(options = {}) {
+  const format = String(options.format || "png").toLowerCase();
+  const mime = format === "webp" ? "image/webp" : "image/png";
+  const report = await runNode2CaptureFrameSpike({
+    ...options,
+    target: options.target || "commonRoot",
+    includeCanvas: true,
+    log: options.debug ? console.log : null,
+  });
+  if (report.error) {
+    throw new Error(`Node 2.0 capture failed: ${report.error.message || "unknown error"}`);
+  }
+  if (!report.canvas || !report.frame?.blobOk) {
+    throw new Error("Node 2.0 capture failed: no captured frame was produced.");
+  }
+  const blob = await toBlob(report.canvas, mime);
+  const warnings = collectNode2Warnings(options);
+  if (report.restriction?.attempted && !report.restriction.ok) {
+    warnings.push(`node2:target_restriction_failed:${report.restriction.attempted}`);
+  }
+  return {
+    type: "raster",
+    mime,
+    blob,
+    width: report.canvas.width,
+    height: report.canvas.height,
+    cwieWarnings: warnings,
+    node2Report: report,
+  };
+}
+
 async function waitAfterCameraMove() {
   await new Promise((resolve) => requestAnimationFrame(() => resolve()));
   await new Promise((resolve) => requestAnimationFrame(() => resolve()));
@@ -434,7 +504,7 @@ function setCanvasView(ds, offset, scale) {
 }
 
 export async function runNode2TileProbe(options = {}) {
-  const log = options.log || console.log;
+  const log = Object.hasOwn(options, "log") ? options.log : console.log;
   const canvas = app?.canvas;
   const ds = canvas?.ds;
   if (!canvas?.canvas || !ds || !Array.isArray(ds.offset)) {

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -2,6 +2,7 @@ import { app } from "/scripts/app.js";
 import { computeGraphBBox } from "../../export/bbox.mjs";
 
 const SPIKE_STYLE_ID = "cwie-node2-spike-style";
+const NODE2_CAPTURE_VERSION = "node2-dom-fit-2026-06-07-2";
 
 function logStep(log, label, payload) {
   log?.(`[CWIE][Node2Spike] ${label}`, payload);
@@ -78,6 +79,7 @@ export function inspectNode2Targets() {
   };
 
   return {
+    version: NODE2_CAPTURE_VERSION,
     api: getApiSupport(),
     appCanvas: describeElement(app?.canvas?.canvas || null),
     candidates: Object.fromEntries(
@@ -88,6 +90,7 @@ export function inspectNode2Targets() {
       vueNodes: vueNodeCount,
     },
     likelyNode2: Boolean(transformPane && linkOverlayCanvas),
+    fit: inspectNode2FitMetrics(),
   };
 }
 
@@ -304,6 +307,41 @@ function measureNode2DomGraphBBox(root, ds) {
     maxY,
     width: Math.max(1, maxX - minX),
     height: Math.max(1, maxY - minY),
+  };
+}
+
+export function inspectNode2FitMetrics() {
+  const { root } = getNode2Layers();
+  const canvas = app?.canvas;
+  const ds = canvas?.ds;
+  const graph = app?.graph || canvas?.graph;
+  const rootRect = root?.getBoundingClientRect?.() || null;
+  const domGraphBBox = root && ds ? measureNode2DomGraphBBox(root, ds) : null;
+  let graphBBox = null;
+  try {
+    graphBBox = graph ? computeGraphBBox(graph, { padding: 0, useBounding: true }) : null;
+  } catch (_) {
+    graphBBox = null;
+  }
+  return {
+    version: NODE2_CAPTURE_VERSION,
+    rootRect: rootRect
+      ? {
+        width: rootRect.width,
+        height: rootRect.height,
+        left: rootRect.left,
+        top: rootRect.top,
+      }
+      : null,
+    currentTransform: ds
+      ? {
+        scale: ds.scale,
+        offset: Array.isArray(ds.offset) ? [ds.offset[0], ds.offset[1]] : null,
+      }
+      : null,
+    nodeCount: root?.querySelectorAll?.("[data-node-id]")?.length || 0,
+    domGraphBBox,
+    graphBBox,
   };
 }
 
@@ -663,6 +701,7 @@ async function withFitNode2View(options, fn) {
   canvas.setDirty?.(true, true);
   await waitForNode2CameraSettle();
   const fitInfo = {
+    version: NODE2_CAPTURE_VERSION,
     bbox,
     rootRect: {
       width: rect.width,
@@ -672,6 +711,7 @@ async function withFitNode2View(options, fn) {
     scale,
     offset: [ds.offset[0], ds.offset[1]],
     cropPaddingPx: Math.max(8, Math.min(128, Number(options.cropPaddingPx) || 56)),
+    metricsAfterFit: inspectNode2FitMetrics(),
   };
   try {
     return await fn(fitInfo);
@@ -750,6 +790,7 @@ export async function captureNode2(options = {}) {
   const format = String(options.format || "png").toLowerCase();
   const mime = format === "webp" ? "image/webp" : "image/png";
   const report = await withFitNode2View(options, async (fitInfo) => {
+    logStep(options.debug ? console.log : null, "capture.fit", fitInfo);
     const captured = await runNode2CaptureFrameSpike({
       ...options,
       target: options.target || "commonRoot",
@@ -767,6 +808,14 @@ export async function captureNode2(options = {}) {
         croppedHeight: captured.canvas.height,
       };
       captured.fit = fitInfo;
+      logStep(options.debug ? console.log : null, "capture.crop", {
+        version: NODE2_CAPTURE_VERSION,
+        croppedWidth: captured.canvas.width,
+        croppedHeight: captured.canvas.height,
+        cropRectCss: fitInfo.cropRectCss,
+        bbox: fitInfo.bbox,
+        metricsAfterFit: fitInfo.metricsAfterFit,
+      });
     }
     return captured;
   });

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -271,6 +271,42 @@ function measureNode2DomCropRect(root, paddingPx) {
   };
 }
 
+function measureNode2DomGraphBBox(root, ds) {
+  if (!root || !ds || !Array.isArray(ds.offset)) return null;
+  const scale = Number(ds.scale) || 1;
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  const rootRect = root.getBoundingClientRect();
+  const nodeRects = asArray(root.querySelectorAll("[data-node-id]"))
+    .map((node) => node.getBoundingClientRect())
+    .filter((rect) => rect.width > 0 && rect.height > 0);
+  if (!nodeRects.length) return null;
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const rect of nodeRects) {
+    const left = ((rect.left - rootRect.left) / scale) - ds.offset[0];
+    const top = ((rect.top - rootRect.top) / scale) - ds.offset[1];
+    const right = ((rect.right - rootRect.left) / scale) - ds.offset[0];
+    const bottom = ((rect.bottom - rootRect.top) / scale) - ds.offset[1];
+    minX = Math.min(minX, left);
+    minY = Math.min(minY, top);
+    maxX = Math.max(maxX, right);
+    maxY = Math.max(maxY, bottom);
+  }
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    return null;
+  }
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}
+
 function stopStream(stream) {
   for (const track of stream?.getTracks?.() || []) {
     track.stop();
@@ -608,7 +644,7 @@ async function withFitNode2View(options, fn) {
   };
   const rect = root.getBoundingClientRect();
   const paddingPx = Math.max(24, Math.min(96, Number(options.fitPaddingPx) || 64));
-  const bbox = computeGraphBBox(graph, {
+  const bbox = measureNode2DomGraphBBox(root, ds) || computeGraphBBox(graph, {
     padding: 0,
     useBounding: true,
     debug: Boolean(options.debug),

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -370,6 +370,102 @@ function createNode2CanvasInfoHider(canvas) {
   };
 }
 
+function createNode2BackgroundOverride(options = {}) {
+  const mode = String(options.background || "ui");
+  if (mode !== "solid") {
+    return { async apply() {}, async restore() {} };
+  }
+  const color = typeof options.solidColor === "string" && options.solidColor.trim()
+    ? options.solidColor.trim()
+    : "#000000";
+  const solidDataUrl = createSolidBackgroundDataUrl(color);
+  const changedElements = new Map();
+  const changedCanvas = new Map();
+  let documentBgImg = null;
+  let documentBgImgPriority = "";
+
+  const saveElement = (el) => {
+    if (!(el instanceof HTMLElement) || changedElements.has(el)) return;
+    changedElements.set(el, {
+      background: el.style.background,
+      backgroundColor: el.style.backgroundColor,
+      backgroundImage: el.style.backgroundImage,
+    });
+  };
+  const saveCanvasProp = (canvas, key) => {
+    if (!canvas || changedCanvas.has(key)) return;
+    changedCanvas.set(key, canvas[key]);
+  };
+  const redraw = () => {
+    const canvas = app?.canvas;
+    canvas?.setDirty?.(true, true);
+    canvas?.setDirtyCanvas?.(true, true);
+    try {
+      canvas?.draw?.(true, true);
+    } catch (_) {}
+  };
+  return {
+    async apply() {
+      const { root } = getNode2Layers();
+      const graphContainer = document.querySelector("#graph-canvas-container");
+      documentBgImg = document.documentElement.style.getPropertyValue("--bg-img");
+      documentBgImgPriority = document.documentElement.style.getPropertyPriority("--bg-img");
+      document.documentElement.style.setProperty("--bg-img", `url("${solidDataUrl}")`);
+      for (const el of [root, graphContainer]) {
+        if (!(el instanceof HTMLElement)) continue;
+        saveElement(el);
+        // ComfyUI's Canvas.BackgroundImage mode makes the canvas clear transparent
+        // so the CSS background behind the graph remains visible while links/nodes draw on top.
+        el.style.background = `${color} url("${solidDataUrl}") repeat`;
+        el.style.backgroundColor = color;
+        el.style.backgroundImage = `url("${solidDataUrl}")`;
+      }
+      const canvas = app?.canvas;
+      if (canvas) {
+        saveCanvasProp(canvas, "clear_background_color");
+        saveCanvasProp(canvas, "background_image");
+        saveCanvasProp(canvas, "_pattern");
+        canvas.clear_background_color = "transparent";
+        canvas.background_image = null;
+        canvas._pattern = undefined;
+      }
+      redraw();
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    },
+    async restore() {
+      if (documentBgImg === "") {
+        document.documentElement.style.removeProperty("--bg-img");
+      } else if (documentBgImg !== null) {
+        document.documentElement.style.setProperty("--bg-img", documentBgImg, documentBgImgPriority);
+      }
+      for (const [el, style] of Array.from(changedElements.entries()).reverse()) {
+        el.style.background = style.background;
+        el.style.backgroundColor = style.backgroundColor;
+        el.style.backgroundImage = style.backgroundImage;
+      }
+      const canvas = app?.canvas;
+      for (const [key, value] of changedCanvas.entries()) {
+        try {
+          canvas[key] = value;
+        } catch (_) {}
+      }
+      changedElements.clear();
+      changedCanvas.clear();
+      documentBgImg = null;
+      documentBgImgPriority = "";
+      redraw();
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    },
+  };
+}
+
+function createSolidBackgroundDataUrl(color) {
+  const safeColor = /^#[0-9a-f]{3}(?:[0-9a-f]{3})?$/i.test(color) ? color : "#000000";
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="${safeColor}"/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
 function hideNode2CaptureChrome(hider) {
   const { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes } = getNode2Layers();
   if (!root) return;
@@ -1431,12 +1527,14 @@ export async function captureNode2SingleFrame(options = {}) {
   const captureHandle = await maybeSetCaptureHandle(log);
   const chromeHider = createNode2ChromeHider();
   const canvasInfoHider = createNode2CanvasInfoHider(app?.canvas);
+  const backgroundOverride = createNode2BackgroundOverride(options);
 
   let stream = null;
   let interactionShield = null;
   try {
     stream = await requestDisplayMedia(log);
     document.documentElement.classList.add("cwie-node2-capturing");
+    await backgroundOverride.apply();
     canvasInfoHider.hide();
     hideNode2CaptureChrome(chromeHider);
     hideKnownComfyChrome(chromeHider);
@@ -1454,6 +1552,7 @@ export async function captureNode2SingleFrame(options = {}) {
     interactionShield?.remove();
     stopStream(stream);
     chromeHider.restore();
+    await backgroundOverride.restore();
     canvasInfoHider.restore();
     document.documentElement.classList.remove("cwie-node2-capturing");
   }
@@ -1764,6 +1863,7 @@ async function captureNode2TiledFromFit(fitInfo, options = {}) {
   const captureHandle = await maybeSetCaptureHandle(log);
   const chromeHider = createNode2ChromeHider();
   const canvasInfoHider = createNode2CanvasInfoHider(canvas);
+  const backgroundOverride = createNode2BackgroundOverride(options);
 
   ensureNode2CaptureStyle();
 
@@ -1773,6 +1873,7 @@ async function captureNode2TiledFromFit(fitInfo, options = {}) {
   try {
     stream = await requestDisplayMedia(log);
     document.documentElement.classList.add("cwie-node2-capturing");
+    await backgroundOverride.apply();
     canvasInfoHider.hide();
     hideNode2CaptureChrome(chromeHider);
     hideKnownComfyChrome(chromeHider);
@@ -2002,6 +2103,7 @@ async function captureNode2TiledFromFit(fitInfo, options = {}) {
     releaseHiddenVideo(prepared?.video);
     stopStream(stream);
     chromeHider.restore();
+    await backgroundOverride.restore();
     canvasInfoHider.restore();
     document.documentElement.classList.remove("cwie-node2-capturing");
     setNode2CanvasView(canvas, ds, saved.offset, saved.scale);
@@ -2025,9 +2127,6 @@ function collectNode2Warnings(options = {}) {
   const warnings = [];
   if (options.background === "transparent") {
     warnings.push("node2:transparent_background_unsupported");
-  }
-  if (options.background === "solid") {
-    warnings.push("node2:solid_background_best_effort");
   }
   if (Number(options.padding) > 0) {
     warnings.push("node2:padding_unsupported");

--- a/web/js/core/backends/node2_compositor_capture.mjs
+++ b/web/js/core/backends/node2_compositor_capture.mjs
@@ -1,11 +1,18 @@
 import { app } from "/scripts/app.js";
 import { computeGraphBBox } from "../../export/bbox.mjs";
 
-const SPIKE_STYLE_ID = "cwie-node2-spike-style";
-const NODE2_CAPTURE_VERSION = "node2-dom-fit-2026-06-07-2";
+const NODE2_CAPTURE_STYLE_ID = "cwie-node2-capture-style";
+const NODE2_CAPTURE_VERSION = "node2-faster-tiles-2026-06-07-1";
+const NODE2_TILE_MAX_PIXELS = 64 * 1024 * 1024;
+const NODE2_TILE_SETTLE_MS = 180;
+const NODE2_TILE_POLL_MIN_WAIT_MS = 80;
+const NODE2_TILE_POLL_INTERVAL_MS = 60;
+
+let node2CaptureInFlight = false;
 
 function logStep(log, label, payload) {
-  log?.(`[CWIE][Node2Spike] ${label}`, payload);
+  if (!log) return;
+  log(`[CWIE][Node2] ${label}`, typeof payload === "function" ? payload() : payload);
 }
 
 function asArray(value) {
@@ -31,6 +38,29 @@ function describeElement(el) {
       }
       : null,
   };
+}
+
+function describeRect(rect) {
+  if (!rect) return null;
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+    right: rect.right,
+    bottom: rect.bottom,
+  };
+}
+
+function snapshotNode2RawRects(root, limit = 8) {
+  if (!root) return [];
+  return asArray(root.querySelectorAll("[data-node-id]"))
+    .slice(0, Math.max(1, limit))
+    .map((node) => ({
+      id: node.getAttribute("data-node-id") || "",
+      title: (node.textContent || "").trim().split(/\n/)[0] || "",
+      rect: describeRect(node.getBoundingClientRect()),
+    }));
 }
 
 function getViewportRect() {
@@ -66,6 +96,26 @@ function getCapturableRootRect(root) {
   };
 }
 
+function getEffectiveCapturableRootRect(root, source = null) {
+  const rect = getCapturableRootRect(root);
+  if (!rect || !source) return rect;
+  const sourceWidth = Number(source.videoWidth || source.width);
+  const sourceHeight = Number(source.videoHeight || source.height);
+  if (!Number.isFinite(sourceWidth) || !Number.isFinite(sourceHeight) || sourceWidth <= 0 || sourceHeight <= 0) {
+    return rect;
+  }
+  const viewport = getViewportRect();
+  const pxPerCss = sourceWidth / Math.max(1, viewport.width);
+  if (!Number.isFinite(pxPerCss) || pxPerCss <= 0) return rect;
+  const effectiveViewportBottom = viewport.top + (sourceHeight / pxPerCss);
+  const bottom = Math.min(rect.bottom, effectiveViewportBottom);
+  return {
+    ...rect,
+    bottom,
+    height: Math.max(1, bottom - rect.top),
+  };
+}
+
 function getApiSupport() {
   const proto = typeof BrowserCaptureMediaStreamTrack !== "undefined"
     ? BrowserCaptureMediaStreamTrack.prototype
@@ -80,6 +130,7 @@ function getApiSupport() {
     cropTarget: typeof window.CropTarget?.fromElement === "function",
     cropTo: typeof proto?.cropTo === "function",
     imageCapture: typeof window.ImageCapture === "function",
+    mediaStreamTrackProcessor: typeof window.MediaStreamTrackProcessor === "function",
     requestVideoFrameCallback: typeof HTMLVideoElement !== "undefined" &&
       typeof HTMLVideoElement.prototype.requestVideoFrameCallback === "function",
   };
@@ -142,10 +193,10 @@ function resolveTarget(name = "commonRoot") {
   return targets[name] || commonRoot || transformPane || graphCanvas;
 }
 
-function ensureSpikeStyle() {
-  if (document.getElementById(SPIKE_STYLE_ID)) return;
+function ensureNode2CaptureStyle() {
+  if (document.getElementById(NODE2_CAPTURE_STYLE_ID)) return;
   const style = document.createElement("style");
-  style.id = SPIKE_STYLE_ID;
+  style.id = NODE2_CAPTURE_STYLE_ID;
   style.textContent = `
     html.cwie-node2-capturing [data-testid="selection-toolbox"],
     html.cwie-node2-capturing [data-testid="node-searchbox-popover"],
@@ -173,12 +224,68 @@ function ensureSpikeStyle() {
       visibility: hidden !important;
     }
 
-    html.cwie-node2-capturing #graph-canvas-container,
-    html.cwie-node2-capturing #graph-canvas-container * {
+    html.cwie-node2-capturing,
+    html.cwie-node2-capturing * {
       cursor: none !important;
+    }
+
+    html.cwie-node2-capturing #graph-canvas-container {
+      isolation: isolate !important;
+      pointer-events: none !important;
+      user-select: none !important;
+    }
+
+    .cwie-node2-pointer-shield {
+      position: fixed !important;
+      inset: 0 !important;
+      z-index: 2147483647 !important;
+      cursor: none !important;
+      pointer-events: auto !important;
+      background: transparent !important;
     }
   `;
   document.head.appendChild(style);
+}
+
+function createNode2InteractionShield() {
+  const shield = document.createElement("div");
+  shield.className = "cwie-node2-pointer-shield";
+  shield.setAttribute("aria-hidden", "true");
+  const stop = (event) => {
+    event.preventDefault?.();
+    event.stopImmediatePropagation?.();
+    event.stopPropagation?.();
+  };
+  const events = [
+    "pointermove",
+    "pointerdown",
+    "pointerup",
+    "pointercancel",
+    "mousemove",
+    "mousedown",
+    "mouseup",
+    "click",
+    "dblclick",
+    "contextmenu",
+    "wheel",
+    "touchstart",
+    "touchmove",
+    "touchend",
+  ];
+  for (const type of events) {
+    shield.addEventListener(type, stop, { capture: true, passive: false });
+    window.addEventListener(type, stop, { capture: true, passive: false });
+  }
+  document.body.appendChild(shield);
+  return {
+    remove() {
+      for (const type of events) {
+        shield.removeEventListener(type, stop, { capture: true });
+        window.removeEventListener(type, stop, { capture: true });
+      }
+      shield.remove();
+    },
+  };
 }
 
 function getNode2Layers() {
@@ -191,11 +298,82 @@ function getNode2Layers() {
   return { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes };
 }
 
-function hideNode2CaptureChrome() {
+function createNode2ChromeHider() {
+  const changed = new Map();
+  return {
+    hide(el) {
+      if (!(el instanceof HTMLElement)) return;
+      if (!changed.has(el)) {
+        changed.set(el, {
+          visibility: el.style.visibility,
+          pointerEvents: el.style.pointerEvents,
+        });
+      }
+      el.style.visibility = "hidden";
+      el.style.pointerEvents = "none";
+    },
+    restore() {
+      for (const [el, style] of Array.from(changed.entries()).reverse()) {
+        el.style.visibility = style.visibility;
+        el.style.pointerEvents = style.pointerEvents;
+      }
+      changed.clear();
+    },
+  };
+}
+
+function createNode2CanvasInfoHider(canvas) {
+  const forceFalseKeys = [
+    "render_canvas_border",
+    "render_canvas_info",
+    "show_canvas_info",
+    "render_info",
+    "show_info",
+    "draw_info",
+    "render_fps",
+    "show_fps",
+    "show_stats",
+    "render_stats",
+  ];
+  const changed = new Map();
+  return {
+    hide() {
+      if (!canvas) return;
+      for (const key of forceFalseKeys) {
+        try {
+          if (key in canvas && !changed.has(key)) {
+            changed.set(key, canvas[key]);
+            canvas[key] = false;
+          }
+        } catch (_) {}
+      }
+      canvas.setDirty?.(true, true);
+      canvas.setDirtyCanvas?.(true, true);
+      try {
+        canvas.draw?.(true, true);
+      } catch (_) {}
+    },
+    restore() {
+      if (!canvas) return;
+      for (const [key, value] of changed.entries()) {
+        try {
+          canvas[key] = value;
+        } catch (_) {}
+      }
+      changed.clear();
+      canvas.setDirty?.(true, true);
+      canvas.setDirtyCanvas?.(true, true);
+      try {
+        canvas.draw?.(true, true);
+      } catch (_) {}
+    },
+  };
+}
+
+function hideNode2CaptureChrome(hider) {
   const { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes } = getNode2Layers();
-  if (!root) return () => {};
+  if (!root) return;
   const keepTree = [graphCanvas, linkOverlayCanvas].filter(Boolean);
-  const changed = [];
   const shouldKeep = (el) => {
     if (!el || el === root || el === transformPane) return true;
     if (keepTree.some((keep) => el === keep || keep.contains(el))) return true;
@@ -203,19 +381,11 @@ function hideNode2CaptureChrome() {
   };
   for (const el of asArray(root.querySelectorAll("*"))) {
     if (!(el instanceof HTMLElement) || shouldKeep(el)) continue;
-    changed.push([el, el.style.visibility, el.style.pointerEvents]);
-    el.style.visibility = "hidden";
-    el.style.pointerEvents = "none";
+    hider.hide(el);
   }
-  return () => {
-    for (const [el, visibility, pointerEvents] of changed) {
-      el.style.visibility = visibility;
-      el.style.pointerEvents = pointerEvents;
-    }
-  };
 }
 
-function hideKnownComfyChrome() {
+function hideKnownComfyChrome(hider) {
   const selectors = [
     "#comfyui-body-top",
     "#comfyui-body-left",
@@ -229,20 +399,11 @@ function hideKnownComfyChrome() {
     '[class*="actionbar" i]',
     '[class*="topbar" i]',
   ];
-  const changed = [];
   for (const el of asArray(document.querySelectorAll(selectors.join(",")))) {
     if (!(el instanceof HTMLElement)) continue;
     if (el.closest("[data-node-id]")) continue;
-    changed.push([el, el.style.visibility, el.style.pointerEvents]);
-    el.style.visibility = "hidden";
-    el.style.pointerEvents = "none";
+    hider.hide(el);
   }
-  return () => {
-    for (const [el, visibility, pointerEvents] of changed) {
-      el.style.visibility = visibility;
-      el.style.pointerEvents = pointerEvents;
-    }
-  };
 }
 
 function rectsIntersect(a, b) {
@@ -259,12 +420,11 @@ function isVisibleElement(el) {
   return !Number.isFinite(opacity) || opacity > 0.01;
 }
 
-function hideIntersectingChrome() {
+function hideIntersectingChrome(hider) {
   const { root, graphCanvas, transformPane, linkOverlayCanvas, vueNodes } = getNode2Layers();
-  if (!root) return () => {};
+  if (!root) return;
   const rootRect = root.getBoundingClientRect();
   const keep = [root, graphCanvas, transformPane, linkOverlayCanvas].filter(Boolean);
-  const changed = [];
   for (const el of asArray(document.body.querySelectorAll("*"))) {
     if (!(el instanceof HTMLElement)) continue;
     if (keep.includes(el)) continue;
@@ -272,6 +432,11 @@ function hideIntersectingChrome() {
     if (el.closest(".cwie-dialog") || el.closest(".cwie-backdrop")) continue;
     const rect = el.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0 || !rectsIntersect(rect, rootRect)) continue;
+    const text = (el.textContent || "").trim();
+    if (text.length <= 80 && /\b\d+(?:\.\d+)?px\s*[×x]\s*\d+(?:\.\d+)?px\b/i.test(text)) {
+      hider.hide(el);
+      continue;
+    }
     const style = window.getComputedStyle(el);
     const zIndex = Number.parseInt(style.zIndex, 10);
     const positioned = style.position === "fixed" ||
@@ -279,16 +444,8 @@ function hideIntersectingChrome() {
       style.position === "absolute" ||
       Number.isFinite(zIndex);
     if (!positioned) continue;
-    changed.push([el, el.style.visibility, el.style.pointerEvents]);
-    el.style.visibility = "hidden";
-    el.style.pointerEvents = "none";
+    hider.hide(el);
   }
-  return () => {
-    for (const [el, visibility, pointerEvents] of changed) {
-      el.style.visibility = visibility;
-      el.style.pointerEvents = pointerEvents;
-    }
-  };
 }
 
 function collectNode2VisualRects(root) {
@@ -370,6 +527,324 @@ function measureNode2DomGraphBBox(root, ds) {
   };
 }
 
+function mapNode2DomElementsById(root) {
+  const map = new Map();
+  if (!root) return map;
+  for (const el of asArray(root.querySelectorAll("[data-node-id]"))) {
+    const id = el.getAttribute("data-node-id");
+    if (id != null && id !== "") {
+      map.set(String(id), el);
+    }
+  }
+  return map;
+}
+
+function getNodePos(node) {
+  if (Array.isArray(node?.pos)) return node.pos;
+  if (Array.isArray(node?.pos2)) return node.pos2;
+  if (Number.isFinite(Number(node?.x)) && Number.isFinite(Number(node?.y))) {
+    return [Number(node.x), Number(node.y)];
+  }
+  return null;
+}
+
+function getNodeSize(node) {
+  if (Array.isArray(node?.size)) return node.size;
+  if (Array.isArray(node?.bounding)) return [node.bounding[2], node.bounding[3]];
+  if (Number.isFinite(Number(node?.width)) && Number.isFinite(Number(node?.height))) {
+    return [Number(node.width), Number(node.height)];
+  }
+  return null;
+}
+
+function getGraphNodes(graph) {
+  return asArray(graph?._nodes || graph?.nodes);
+}
+
+function getNodeId(node) {
+  return node?.id == null ? null : String(node.id);
+}
+
+function normalizeNodeId(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  if (!text) return null;
+  const numeric = text.match(/(?:^|[^0-9])([0-9]+)(?:[^0-9]|$)/);
+  return numeric ? numeric[1] : text;
+}
+
+function getNodeTitle(node) {
+  return String(node?.title || node?.type || node?.comfyClass || "").trim();
+}
+
+function getDomNodeTitle(el) {
+  return String(el?.textContent || "").trim().split(/\n/)[0]?.trim() || "";
+}
+
+function normalizeTitle(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function measureNode2GraphBBox(graph) {
+  const nodes = getGraphNodes(graph);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let measuredNodes = 0;
+
+  for (const node of nodes) {
+    const pos = getNodePos(node);
+    const size = getNodeSize(node);
+    const left = Number(pos?.[0]);
+    const top = Number(pos?.[1]);
+    const width = Number(size?.[0]);
+    const height = Number(size?.[1]);
+    if (!Number.isFinite(left) || !Number.isFinite(top) ||
+      !Number.isFinite(width) || !Number.isFinite(height) ||
+      width <= 0 || height <= 0) {
+      continue;
+    }
+    measuredNodes += 1;
+    minX = Math.min(minX, left);
+    minY = Math.min(minY, top);
+    maxX = Math.max(maxX, left + width);
+    maxY = Math.max(maxY, top + height);
+  }
+
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    return null;
+  }
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+    measuredNodes,
+  };
+}
+
+function buildNode2DomLookup(root) {
+  const byId = new Map();
+  const byTitle = new Map();
+  const nodes = [];
+  if (!root) return { byId, byTitle, nodes };
+  for (const el of asArray(root.querySelectorAll("[data-node-id]"))) {
+    const rawId = el.getAttribute("data-node-id");
+    const idKeys = new Set([
+      rawId,
+      rawId == null ? null : String(rawId),
+      normalizeNodeId(rawId),
+    ].filter(Boolean));
+    for (const key of idKeys) {
+      if (!byId.has(key)) byId.set(key, el);
+    }
+    const title = normalizeTitle(getDomNodeTitle(el));
+    if (title && !byTitle.has(title)) byTitle.set(title, el);
+    nodes.push({
+      rawId,
+      normalizedId: normalizeNodeId(rawId),
+      title: getDomNodeTitle(el),
+      el,
+    });
+  }
+  return { byId, byTitle, nodes };
+}
+
+function resolveNode2DomForGraphNode(lookup, node) {
+  const id = getNodeId(node);
+  const idKeys = [
+    id,
+    normalizeNodeId(id),
+  ].filter(Boolean);
+  for (const key of idKeys) {
+    const found = lookup.byId.get(key);
+    if (found) return found;
+  }
+  const title = normalizeTitle(getNodeTitle(node));
+  return title ? lookup.byTitle.get(title) || null : null;
+}
+
+function buildNode2GraphLookup(graph) {
+  const byId = new Map();
+  const byTitle = new Map();
+  const nodes = [];
+  for (const node of getGraphNodes(graph)) {
+    const id = getNodeId(node);
+    const idKeys = [
+      id,
+      normalizeNodeId(id),
+    ].filter(Boolean);
+    for (const key of idKeys) {
+      if (!byId.has(key)) byId.set(key, node);
+    }
+    const title = normalizeTitle(getNodeTitle(node));
+    if (title && !byTitle.has(title)) byTitle.set(title, node);
+    nodes.push(node);
+  }
+  return { byId, byTitle, nodes };
+}
+
+function resolveNode2GraphForDomNode(lookup, domNode) {
+  const rawId = domNode?.rawId;
+  const idKeys = [
+    rawId,
+    normalizeNodeId(rawId),
+  ].filter(Boolean);
+  for (const key of idKeys) {
+    const found = lookup.byId.get(key);
+    if (found) return found;
+  }
+  const title = normalizeTitle(domNode?.title);
+  return title ? lookup.byTitle.get(title) || null : null;
+}
+
+function measureNode2CameraAlignment(root, graph, offset, scale, limit = 6) {
+  if (!root || !graph || !Array.isArray(offset)) {
+    return { ok: false, reason: "missing_root_graph_or_offset", samples: [] };
+  }
+  const rootRect = root.getBoundingClientRect();
+  const domLookup = buildNode2DomLookup(root);
+  const graphLookup = buildNode2GraphLookup(graph);
+  const samples = [];
+  const missing = [];
+  for (const domNode of domLookup.nodes) {
+    if (samples.length >= limit) break;
+    const node = resolveNode2GraphForDomNode(graphLookup, domNode);
+    const id = getNodeId(node);
+    const pos = getNodePos(node);
+    const dom = domNode.el;
+    if (!id || !pos || !dom) {
+      if (missing.length < limit) {
+        missing.push({
+          domRawId: domNode.rawId,
+          domNormalizedId: domNode.normalizedId,
+          domTitle: domNode.title,
+          graphId: id,
+          graphTitle: getNodeTitle(node),
+          hasPos: Boolean(pos),
+          hasDom: Boolean(dom),
+        });
+      }
+      continue;
+    }
+    const rect = dom.getBoundingClientRect();
+    if (rect.width <= 1 || rect.height <= 1) continue;
+    const expectedLeft = (Number(pos[0]) + offset[0]) * scale;
+    const expectedTop = (Number(pos[1]) + offset[1]) * scale;
+    const actualLeft = rect.left - rootRect.left;
+    const actualTop = rect.top - rootRect.top;
+    samples.push({
+      id,
+      dx: actualLeft - expectedLeft,
+      dy: actualTop - expectedTop,
+      expectedLeft,
+      expectedTop,
+      actualLeft,
+      actualTop,
+    });
+  }
+  if (!samples.length) {
+    return {
+      ok: false,
+      reason: "no_matched_dom_nodes",
+      domIds: domLookup.nodes.slice(0, limit).map((node) => ({
+        rawId: node.rawId,
+        normalizedId: node.normalizedId,
+        title: node.title,
+      })),
+      graphIds: graphLookup.nodes.map((node) => ({
+        id: getNodeId(node),
+        normalizedId: normalizeNodeId(getNodeId(node)),
+        title: getNodeTitle(node),
+      })).filter((node) => node.id || node.title).slice(0, limit),
+      missing,
+      samples,
+    };
+  }
+  const maxAbsDx = Math.max(...samples.map((sample) => Math.abs(sample.dx)));
+  const maxAbsDy = Math.max(...samples.map((sample) => Math.abs(sample.dy)));
+  return {
+    ok: maxAbsDx <= 3 && maxAbsDy <= 3,
+    maxAbsDx,
+    maxAbsDy,
+    samples,
+  };
+}
+
+async function setAndWaitNode2CanvasView(canvas, ds, root, graph, offset, scale, log, options = {}) {
+  setNode2CanvasView(canvas, ds, offset, scale);
+  await waitForNode2CameraSettle(Math.max(180, Number(options.settleMs) || 420));
+  const alignment = log ? measureNode2CameraAlignment(root, graph, offset, scale) : null;
+  logStep(log, "capture.tile.camera", {
+    attempts: 1,
+    offset: [offset[0], offset[1]],
+    scale,
+    alignment,
+  });
+  return alignment;
+}
+
+function measureNode2StableGraphBBox(root, ds, graph) {
+  const nodes = asArray(graph?._nodes || graph?.nodes);
+  if (!nodes.length || !ds) return null;
+  const scale = Number(ds.scale) || 1;
+  if (!Number.isFinite(scale) || scale <= 0) return null;
+  const domById = mapNode2DomElementsById(root);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  let measuredDomNodes = 0;
+  let measuredGraphNodes = 0;
+
+  for (const node of nodes) {
+    const pos = getNodePos(node);
+    if (!pos) continue;
+    const left = Number(pos[0]);
+    const top = Number(pos[1]);
+    if (!Number.isFinite(left) || !Number.isFinite(top)) continue;
+
+    const dom = domById.get(String(node.id));
+    const rect = dom?.getBoundingClientRect?.();
+    let width = rect && rect.width > 1 ? rect.width / scale : null;
+    let height = rect && rect.height > 1 ? rect.height / scale : null;
+    if (Number.isFinite(width) && Number.isFinite(height)) {
+      measuredDomNodes += 1;
+    } else {
+      const size = getNodeSize(node);
+      width = Number(size?.[0]);
+      height = Number(size?.[1]);
+      if (Number.isFinite(width) && Number.isFinite(height)) {
+        measuredGraphNodes += 1;
+      }
+    }
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      continue;
+    }
+    minX = Math.min(minX, left);
+    minY = Math.min(minY, top);
+    maxX = Math.max(maxX, left + width);
+    maxY = Math.max(maxY, top + height);
+  }
+
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    return null;
+  }
+  return {
+    minX,
+    minY,
+    maxX,
+    maxY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+    measuredDomNodes,
+    measuredGraphNodes,
+  };
+}
+
 export function inspectNode2FitMetrics() {
   const { root } = getNode2Layers();
   const canvas = app?.canvas;
@@ -377,6 +852,7 @@ export function inspectNode2FitMetrics() {
   const graph = app?.graph || canvas?.graph;
   const rootRect = root?.getBoundingClientRect?.() || null;
   const domGraphBBox = root && ds ? measureNode2DomGraphBBox(root, ds) : null;
+  const stableGraphBBox = root && ds && graph ? measureNode2StableGraphBBox(root, ds, graph) : null;
   let graphBBox = null;
   try {
     graphBBox = graph ? computeGraphBBox(graph, { padding: 0, useBounding: true }) : null;
@@ -400,6 +876,8 @@ export function inspectNode2FitMetrics() {
       }
       : null,
     nodeCount: root?.querySelectorAll?.("[data-node-id]")?.length || 0,
+    rawNodeRects: snapshotNode2RawRects(root, 8),
+    stableGraphBBox,
     domGraphBBox,
     graphBBox,
   };
@@ -407,7 +885,56 @@ export function inspectNode2FitMetrics() {
 
 function stopStream(stream) {
   for (const track of stream?.getTracks?.() || []) {
-    track.stop();
+    try {
+      track.stop();
+    } catch (_) {
+      // Ignore cleanup failures. The browser may already have ended the track.
+    }
+  }
+}
+
+function releaseHiddenVideo(video) {
+  if (!video) return;
+  try {
+    video.pause?.();
+  } catch (_) {
+    // best-effort cleanup
+  }
+  try {
+    video.srcObject = null;
+  } catch (_) {
+    // best-effort cleanup
+  }
+  try {
+    video.removeAttribute?.("src");
+  } catch (_) {
+    // best-effort cleanup
+  }
+  try {
+    video.load?.();
+  } catch (_) {
+    // best-effort cleanup
+  }
+  try {
+    video.remove?.();
+  } catch (_) {
+    // best-effort cleanup
+  }
+}
+
+function releaseCanvasResource(canvas) {
+  if (!canvas) return;
+  try {
+    const ctx = canvas.getContext?.("2d");
+    ctx?.clearRect?.(0, 0, canvas.width || 0, canvas.height || 0);
+  } catch (_) {
+    // best-effort cleanup
+  }
+  try {
+    canvas.width = 0;
+    canvas.height = 0;
+  } catch (_) {
+    // best-effort cleanup
   }
 }
 
@@ -486,7 +1013,16 @@ async function attachHiddenVideo(stream, log) {
   video.muted = true;
   video.playsInline = true;
   video.autoplay = true;
-  video.style.cssText = "position:fixed;left:-10000px;top:-10000px;width:1px;height:1px;opacity:0;pointer-events:none;";
+  video.style.cssText = [
+    "position:fixed",
+    "left:8px",
+    "top:8px",
+    "width:320px",
+    "height:180px",
+    "opacity:0.02",
+    "z-index:2147483647",
+    "pointer-events:none",
+  ].join(";");
   video.srcObject = stream;
   document.body.appendChild(video);
   logStep(log, "video.attach", {
@@ -530,6 +1066,126 @@ async function canvasProbe(canvas, ctx, width, height) {
     sampleAlpha: sample[3],
     hasAlphaChannelData: sample[3] < 255,
   };
+}
+
+function sampleCanvasSignature(ctx, width, height) {
+  const sampleCols = 96;
+  const sampleRows = 54;
+  const sampleCanvas = document.createElement("canvas");
+  sampleCanvas.width = sampleCols;
+  sampleCanvas.height = sampleRows;
+  const sampleCtx = sampleCanvas.getContext("2d", {
+    alpha: true,
+    willReadFrequently: true,
+  });
+  if (!sampleCtx) return null;
+  sampleCtx.drawImage(ctx.canvas, 0, 0, width, height, 0, 0, sampleCols, sampleRows);
+  const pixels = sampleCtx.getImageData(0, 0, sampleCols, sampleRows).data;
+  let hash = 2166136261;
+  for (let i = 0; i < pixels.length; i += 4) {
+    hash ^= pixels[i];
+    hash = Math.imul(hash, 16777619);
+    hash ^= pixels[i + 1];
+    hash = Math.imul(hash, 16777619);
+    hash ^= pixels[i + 2];
+    hash = Math.imul(hash, 16777619);
+    hash ^= pixels[i + 3];
+    hash = Math.imul(hash, 16777619);
+  }
+  return `${sampleCols}x${sampleRows}:${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+async function captureChangedVideoFrame(prepared, options, log) {
+  const timeoutMs = Math.max(500, Number(options.frameTimeoutMs) || 3000);
+  const intervalMs = Math.max(40, Math.min(250, Number(options.pollIntervalMs) || 120));
+  const minWaitMs = Math.max(0, Number(options.pollMinWaitMs) || 240);
+  const started = performance.now();
+  let last = null;
+  let attempts = 0;
+
+  while (performance.now() - started < timeoutMs) {
+    attempts += 1;
+    await waitVideoPollDelay(attempts === 1 ? minWaitMs : intervalMs);
+    const { canvas, ctx, width, height } = drawVideoToCanvas(prepared.video);
+    const signature = sampleCanvasSignature(ctx, width, height);
+    if (last?.canvas && last.canvas !== canvas) {
+      releaseCanvasResource(last.canvas);
+    }
+    last = { canvas, ctx, width, height, signature };
+    if (!prepared.lastFrameSignature || signature !== prepared.lastFrameSignature) {
+      prepared.lastFrameSignature = signature;
+      const probe = options.probe === false
+        ? { blobOk: true, blobType: null, blobSize: 0, probed: false }
+        : await canvasProbe(canvas, ctx, width, height);
+      const frame = {
+        width,
+        height,
+        dpr: window.devicePixelRatio || 1,
+        polledFrame: true,
+        signature,
+        attempts,
+        ...probe,
+      };
+      logStep(log, "frame.polled.ok", frame);
+      return {
+        startedAt: new Date().toISOString(),
+        targetName: prepared.targetName,
+        before: inspectNode2Targets(),
+        track: prepared.track,
+        restriction: prepared.restriction,
+        frame,
+        canvas,
+      };
+    }
+    logStep(log, "frame.polled.stale", {
+      signature,
+      attempts,
+      elapsedMs: Math.round(performance.now() - started),
+    });
+  }
+
+  if (!last) {
+    throw new Error(`polled video frame unavailable after ${timeoutMs}ms`);
+  }
+
+  const probe = options.probe === false
+    ? { blobOk: true, blobType: null, blobSize: 0, probed: false }
+    : await canvasProbe(last.canvas, last.ctx, last.width, last.height);
+  const frame = {
+    width: last.width,
+    height: last.height,
+    dpr: window.devicePixelRatio || 1,
+    polledFrame: true,
+    unchangedFrame: true,
+    signature: last.signature,
+    attempts,
+    ...probe,
+  };
+  logStep(log, "frame.polled.unchanged.accept", {
+    ...frame,
+    elapsedMs: Math.round(performance.now() - started),
+  });
+  return {
+    startedAt: new Date().toISOString(),
+    targetName: prepared.targetName,
+    before: inspectNode2Targets(),
+    track: prepared.track,
+    restriction: prepared.restriction,
+    frame,
+    canvas: last.canvas,
+  };
+}
+
+async function seedPreparedFrameSignature(prepared, log) {
+  if (!prepared?.video) return null;
+  await waitVideoPollDelay(180);
+  const { canvas, ctx, width, height } = drawVideoToCanvas(prepared.video);
+  const signature = sampleCanvasSignature(ctx, width, height);
+  releaseCanvasResource(canvas);
+  prepared.lastFrameSignature = signature;
+  const seed = { width, height, signature };
+  logStep(log, "frame.seed", seed);
+  return seed;
 }
 
 async function maybeSetCaptureHandle(log) {
@@ -629,11 +1285,82 @@ async function captureFrameFromStream(stream, target, targetName, captureHandle,
     logStep(log, "frame.failed", report.error);
     return report;
   } finally {
-    video.remove();
+    releaseHiddenVideo(video);
   }
 }
 
-async function applyTargetRestriction(track, target, { prefer = "restriction", log } = {}) {
+async function prepareFrameCaptureFromStream(stream, target, targetName, captureHandle, options, log) {
+  const [track] = stream.getVideoTracks();
+  const settings = track?.getSettings?.() || {};
+  const captureHandleInfo = track?.getCaptureHandle?.() || null;
+  const trackReport = {
+    label: track?.label || "",
+    settings,
+    captureHandle: captureHandleInfo,
+    isLikelySelfCapture: captureHandleInfo?.handle === captureHandle.handle ||
+      settings.displaySurface === "browser",
+  };
+  logStep(log, "displayMedia.ok", trackReport);
+
+  const video = await attachHiddenVideo(stream, log);
+  try {
+    const restriction = await applyTargetRestriction(track, target, {
+      prefer: options.prefer || "restriction",
+      requireRestriction: Boolean(options.requireRestriction),
+      log,
+    });
+    logStep(log, "target.apply", restriction);
+    return {
+      targetName,
+      trackObject: track,
+      track: trackReport,
+      restriction,
+      video,
+      lastFrameSignature: null,
+    };
+  } catch (error) {
+    releaseHiddenVideo(video);
+    throw error;
+  }
+}
+
+async function waitVideoPollDelay(ms = 900) {
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+async function captureFrameFromPreparedVideo(prepared, options, log) {
+  if (options.pollChangedFrame) {
+    return captureChangedVideoFrame(prepared, options, log);
+  }
+  const frameCount = Math.max(1, Number(options.frameCount) || 2);
+  const frameTimeoutMs = Math.max(50, Number(options.frameTimeoutMs) || 3000);
+  await waitVideoFrame(prepared.video, frameCount, log, frameTimeoutMs);
+  const { canvas, ctx, width, height } = drawVideoToCanvas(prepared.video);
+  const probe = options.probe === false
+    ? { blobOk: true, blobType: null, blobSize: 0, probed: false }
+    : await canvasProbe(canvas, ctx, width, height);
+  const frame = {
+    width,
+    height,
+    dpr: window.devicePixelRatio || 1,
+    ...probe,
+  };
+  logStep(log, "frame.ok", frame);
+  return {
+    startedAt: new Date().toISOString(),
+    targetName: prepared.targetName,
+    before: inspectNode2Targets(),
+    track: prepared.track,
+    restriction: prepared.restriction,
+    frame,
+    canvas,
+  };
+}
+
+async function applyTargetRestriction(track, target, { prefer = "restriction", requireRestriction = false, log } = {}) {
   const result = {
     target: describeElement(target),
     attempted: null,
@@ -659,7 +1386,17 @@ async function applyTargetRestriction(track, target, { prefer = "restriction", l
     } catch (error) {
       result.error = error?.message || String(error);
       logStep(log, "restrict.failed", result);
+      if (requireRestriction) {
+        throw new Error(`Node 2.0 capture requires RestrictionTarget/restrictTo: ${result.error}`);
+      }
     }
+  }
+
+  if (requireRestriction) {
+    if (!result.attempted) {
+      result.error = "RestrictionTarget/restrictTo is unavailable";
+    }
+    throw new Error(`Node 2.0 capture requires RestrictionTarget/restrictTo: ${result.error || "restriction failed"}`);
   }
 
   const canCrop =
@@ -684,22 +1421,27 @@ async function applyTargetRestriction(track, target, { prefer = "restriction", l
   return result;
 }
 
-export async function runNode2CaptureFrameSpike(options = {}) {
+export async function captureNode2SingleFrame(options = {}) {
   const log = Object.hasOwn(options, "log") ? options.log : console.log;
   const targetName = options.target || "commonRoot";
   const target = resolveTarget(targetName);
   const report = { startedAt: new Date().toISOString(), targetName, before: inspectNode2Targets() };
 
-  ensureSpikeStyle();
+  ensureNode2CaptureStyle();
   const captureHandle = await maybeSetCaptureHandle(log);
-  document.documentElement.classList.add("cwie-node2-capturing");
-  const restoreHiddenChrome = hideNode2CaptureChrome();
-  const restoreKnownChrome = hideKnownComfyChrome();
-  const restoreIntersectingChrome = hideIntersectingChrome();
+  const chromeHider = createNode2ChromeHider();
+  const canvasInfoHider = createNode2CanvasInfoHider(app?.canvas);
 
   let stream = null;
+  let interactionShield = null;
   try {
     stream = await requestDisplayMedia(log);
+    document.documentElement.classList.add("cwie-node2-capturing");
+    canvasInfoHider.hide();
+    hideNode2CaptureChrome(chromeHider);
+    hideKnownComfyChrome(chromeHider);
+    hideIntersectingChrome(chromeHider);
+    interactionShield = createNode2InteractionShield();
     return await captureFrameFromStream(stream, target, targetName, captureHandle, options, log);
   } catch (error) {
     report.error = {
@@ -709,10 +1451,10 @@ export async function runNode2CaptureFrameSpike(options = {}) {
     logStep(log, "failed", report.error);
     return report;
   } finally {
+    interactionShield?.remove();
     stopStream(stream);
-    restoreHiddenChrome();
-    restoreKnownChrome();
-    restoreIntersectingChrome();
+    chromeHider.restore();
+    canvasInfoHider.restore();
     document.documentElement.classList.remove("cwie-node2-capturing");
   }
 }
@@ -722,6 +1464,24 @@ async function waitForNode2CameraSettle(ms = 320) {
   await new Promise((resolve) => requestAnimationFrame(() => resolve()));
   await new Promise((resolve) => setTimeout(resolve, ms));
   await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function setNode2CanvasView(canvas, ds, offset, scale) {
+  ds.scale = scale;
+  ds.offset[0] = offset[0];
+  ds.offset[1] = offset[1];
+  const transformPane = getNode2Layers().transformPane;
+  if (transformPane) {
+    transformPane.style.transform = `scale3d(${scale}, ${scale}, ${scale}) translate3d(${offset[0]}px, ${offset[1]}px, 0)`;
+    transformPane.style.transformOrigin = "0 0";
+  }
+  canvas.setDirty?.(true, true);
+  canvas.setDirtyCanvas?.(true, true);
+  try {
+    canvas.draw?.(true, true);
+  } catch (_) {
+    // Some Node 2.0 builds keep DOM/canvas rendering on their own scheduler.
+  }
 }
 
 async function withFitNode2View(options, fn) {
@@ -755,10 +1515,10 @@ async function withFitNode2View(options, fn) {
   );
   const visibleGraphWidth = rect.width / scale;
   const visibleGraphHeight = rect.height / scale;
-  ds.scale = scale;
-  ds.offset[0] = ((visibleGraphWidth - bbox.width) / 2) - bbox.minX;
-  ds.offset[1] = ((visibleGraphHeight - bbox.height) / 2) - bbox.minY;
-  canvas.setDirty?.(true, true);
+  setNode2CanvasView(canvas, ds, [
+    ((visibleGraphWidth - bbox.width) / 2) - bbox.minX,
+    ((visibleGraphHeight - bbox.height) / 2) - bbox.minY,
+  ], scale);
   await waitForNode2CameraSettle();
   const fitInfo = {
     version: NODE2_CAPTURE_VERSION,
@@ -780,10 +1540,7 @@ async function withFitNode2View(options, fn) {
   try {
     return await fn(fitInfo);
   } finally {
-    ds.scale = original.scale;
-    ds.offset[0] = original.offset[0];
-    ds.offset[1] = original.offset[1];
-    canvas.setDirty?.(true, true);
+    setNode2CanvasView(canvas, ds, original.offset, original.scale);
     await waitForNode2CameraSettle(120);
   }
 }
@@ -858,6 +1615,400 @@ function cropNode2CanvasToFit(canvas, fitInfo) {
   return out;
 }
 
+function cropNode2CanvasToRoot(canvas, root) {
+  const captureRect = getEffectiveCapturableRootRect(root, canvas);
+  if (!canvas || !captureRect) return { canvas, crop: null };
+  const viewport = getViewportRect();
+  const ratioX = canvas.width / Math.max(1, viewport.width);
+  const ratioY = canvas.height / Math.max(1, viewport.height);
+  const leftCss = captureRect.left - viewport.left;
+  const topCss = captureRect.top - viewport.top;
+  const rightCss = captureRect.right - viewport.left;
+  const bottomCss = captureRect.bottom - viewport.top;
+  const sx = Math.max(0, Math.floor(leftCss * ratioX));
+  const sy = Math.max(0, Math.floor(topCss * ratioY));
+  const ex = Math.min(canvas.width, Math.ceil(rightCss * ratioX));
+  const ey = Math.min(canvas.height, Math.ceil(bottomCss * ratioY));
+  const width = Math.max(1, ex - sx);
+  const height = Math.max(1, ey - sy);
+  if (sx === 0 && sy === 0 && width === canvas.width && height === canvas.height) {
+    return {
+      canvas,
+      crop: {
+        captureRect,
+        ratioX,
+        ratioY,
+      },
+    };
+  }
+  const out = document.createElement("canvas");
+  out.width = width;
+  out.height = height;
+  const ctx = out.getContext("2d", { alpha: true });
+  if (!ctx) {
+    return { canvas, crop: null };
+  }
+  ctx.drawImage(canvas, sx, sy, width, height, 0, 0, width, height);
+  return {
+    canvas: out,
+    crop: {
+      captureRect,
+      ratioX,
+      ratioY,
+      sx,
+      sy,
+      width,
+      height,
+    },
+  };
+}
+
+function useRestrictedFrameAsTile(canvas, captureRect) {
+  if (!canvas || !captureRect) return { canvas, crop: null };
+  const ratioX = canvas.width / Math.max(1, captureRect.width);
+  const ratioY = canvas.height / Math.max(1, captureRect.height);
+  return {
+    canvas,
+    crop: {
+      captureRect,
+      ratioX,
+      ratioY,
+      width: canvas.width,
+      height: canvas.height,
+      restrictedFrame: true,
+    },
+  };
+}
+
+function getNode2TileScale(options = {}) {
+  const requested = Number(options.node2TileScale);
+  if (Number.isFinite(requested) && requested > 0) {
+    return Math.max(0.25, Math.min(1.25, requested));
+  }
+  return options.outputResolution === "200%" ? 1.25 : 1;
+}
+
+function shouldUseNode2TiledCapture(options, fitInfo, root) {
+  const requested = options.node2TiledCapture === true ||
+    options.node2TiledCapture === "debug" ||
+    options.exceedMode === "tile";
+  if (!requested || !fitInfo?.bbox || !root) return false;
+  const captureRect = getCapturableRootRect(root);
+  if (!captureRect) return false;
+  const tileScale = getNode2TileScale(options);
+  const padGraph = Math.max(8, Math.min(128, Number(options.cropPaddingPx) || 56)) / tileScale;
+  const graphWidth = fitInfo.bbox.width + padGraph * 2;
+  const graphHeight = fitInfo.bbox.height + padGraph * 2;
+  const dpr = window.devicePixelRatio || 1;
+  return graphWidth * tileScale * dpr * graphHeight * tileScale * dpr <= NODE2_TILE_MAX_PIXELS;
+}
+
+function getNode2CurrentGraphBBox() {
+  const { root } = getNode2Layers();
+  const canvas = app?.canvas;
+  const ds = canvas?.ds;
+  const graph = app?.graph || canvas?.graph;
+  let bbox = graph ? measureNode2GraphBBox(graph) : null;
+  const domGraphBBox = root && ds ? measureNode2DomGraphBBox(root, ds) : null;
+  if (!bbox && graph) {
+    try {
+      bbox = computeGraphBBox(graph, { padding: 0, useBounding: true });
+    } catch (_) {
+      bbox = null;
+    }
+  }
+  if (!bbox) return null;
+  return {
+    version: NODE2_CAPTURE_VERSION,
+    rootRect: root?.getBoundingClientRect?.() || null,
+    currentTransform: ds
+      ? {
+        scale: ds.scale,
+        offset: Array.isArray(ds.offset) ? [ds.offset[0], ds.offset[1]] : null,
+      }
+      : null,
+    bbox,
+    domGraphBBox,
+    metricsAfterFit: inspectNode2FitMetrics(),
+  };
+}
+
+async function captureNode2TiledFromFit(fitInfo, options = {}) {
+  const canvas = app?.canvas;
+  const ds = canvas?.ds;
+  const graph = app?.graph || canvas?.graph;
+  const { root } = getNode2Layers();
+  if (!canvas?.canvas || !ds || !Array.isArray(ds.offset) || !root || !graph || !fitInfo?.bbox) {
+    return null;
+  }
+
+  const targetName = options.target || "commonRoot";
+  const target = resolveTarget(targetName);
+  const tileScale = getNode2TileScale(options);
+  const cropPaddingPx = Math.max(8, Math.min(128, Number(options.cropPaddingPx) || 56));
+  const padGraph = cropPaddingPx / tileScale;
+  const bbox = fitInfo.bbox;
+  const minX = bbox.minX - padGraph;
+  const minY = bbox.minY - padGraph;
+  const maxX = bbox.maxX + padGraph;
+  const maxY = bbox.maxY + padGraph;
+  const graphWidth = Math.max(1, maxX - minX);
+  const graphHeight = Math.max(1, maxY - minY);
+  const saved = {
+    offset: [ds.offset[0], ds.offset[1]],
+    scale: ds.scale || 1,
+  };
+  let output = null;
+  let outputCtx = null;
+  const log = options.debug ? console.log : null;
+  const captureHandle = await maybeSetCaptureHandle(log);
+  const chromeHider = createNode2ChromeHider();
+  const canvasInfoHider = createNode2CanvasInfoHider(canvas);
+
+  ensureNode2CaptureStyle();
+
+  let stream = null;
+  let prepared = null;
+  let interactionShield = null;
+  try {
+    stream = await requestDisplayMedia(log);
+    document.documentElement.classList.add("cwie-node2-capturing");
+    canvasInfoHider.hide();
+    hideNode2CaptureChrome(chromeHider);
+    hideKnownComfyChrome(chromeHider);
+    hideIntersectingChrome(chromeHider);
+    interactionShield = createNode2InteractionShield();
+    prepared = await prepareFrameCaptureFromStream(
+      stream,
+      target,
+      targetName,
+      captureHandle,
+      {
+        ...options,
+        frameCount: 1,
+        frameTimeoutMs: 1500,
+        probe: false,
+        prefer: "restriction",
+        requireRestriction: true,
+      },
+      log
+    );
+    const seedFrame = await seedPreparedFrameSignature(prepared, log);
+    const rootRect = root.getBoundingClientRect();
+    const captureRect = getEffectiveCapturableRootRect(root, prepared.video);
+    if (!rootRect || rootRect.width <= 0 || rootRect.height <= 0 || !captureRect) {
+      return { error: { message: "Node 2.0 tiled capture failed: graph root has no size." } };
+    }
+    const frameCssRatioX = prepared.video.videoWidth / Math.max(1, captureRect.width);
+    const frameCssRatioY = prepared.video.videoHeight / Math.max(1, captureRect.height);
+    const captureOriginX = captureRect.left - rootRect.left;
+    const captureOriginY = captureRect.top - rootRect.top;
+    const visibleGraphWidth = captureRect.width / tileScale;
+    const visibleGraphHeight = captureRect.height / tileScale;
+    const overlapPx = Math.max(0, Math.min(64, Number(options.node2TileOverlapPx) || 16));
+    const overlapGraph = overlapPx / tileScale;
+    const tileStepX = Math.max(1, visibleGraphWidth - overlapGraph * 2);
+    const tileStepY = Math.max(1, visibleGraphHeight - overlapGraph * 2);
+    const cols = graphWidth <= visibleGraphWidth
+      ? 1
+      : Math.ceil((graphWidth - visibleGraphWidth) / tileStepX) + 1;
+    const rows = graphHeight <= visibleGraphHeight
+      ? 1
+      : Math.ceil((graphHeight - visibleGraphHeight) / tileStepY) + 1;
+    const pxPerGraphX = frameCssRatioX * tileScale;
+    const pxPerGraphY = frameCssRatioY * tileScale;
+    const outputWidth = Math.max(1, Math.ceil(graphWidth * pxPerGraphX));
+    const outputHeight = Math.max(1, Math.ceil(graphHeight * pxPerGraphY));
+    output = document.createElement("canvas");
+    output.width = outputWidth;
+    output.height = outputHeight;
+    outputCtx = output.getContext("2d", { alpha: true });
+    if (!outputCtx) {
+      return { error: { message: "Node 2.0 tiled capture failed: 2d context unavailable." } };
+    }
+    outputCtx.clearRect(0, 0, output.width, output.height);
+
+    const tileXs = Array.from({ length: cols }, (_, col) => {
+      const planned = minX + col * tileStepX;
+      return col === cols - 1 ? Math.max(minX, maxX - visibleGraphWidth) : planned;
+    });
+    const tileYs = Array.from({ length: rows }, (_, row) => {
+      const planned = minY + row * tileStepY;
+      return row === rows - 1 ? Math.max(minY, maxY - visibleGraphHeight) : planned;
+    });
+    logStep(log, "capture.tile.plan", () => ({
+      graphWidth,
+      graphHeight,
+      tileStepX,
+      tileStepY,
+      overlapPx,
+      overlapGraph,
+      visibleGraphWidth,
+      visibleGraphHeight,
+      cols,
+      rows,
+      tileXs,
+      tileYs,
+      rootRect: describeRect(rootRect),
+      captureRect,
+      captureOrigin: {
+        x: captureOriginX,
+        y: captureOriginY,
+      },
+      seedFrame,
+      bboxSource: {
+        graph: fitInfo.bbox,
+        dom: fitInfo.domGraphBBox || null,
+      },
+      video: {
+        width: prepared.video.videoWidth,
+        height: prepared.video.videoHeight,
+      },
+      frameCssRatio: {
+        x: frameCssRatioX,
+        y: frameCssRatioY,
+      },
+      output: {
+        width: output.width,
+        height: output.height,
+        pxPerGraphX,
+        pxPerGraphY,
+      },
+    }));
+    for (let row = 0; row < rows; row += 1) {
+      for (let col = 0; col < cols; col += 1) {
+        const tileStarted = performance.now();
+        const tileIndex = row * cols + col;
+        options.onProgress?.({
+          value: tileIndex / Math.max(1, rows * cols),
+          percent: Math.round((tileIndex / Math.max(1, rows * cols)) * 100),
+        });
+        const tileX = tileXs[col];
+        const tileY = tileYs[row];
+        const tileOffset = [
+          (captureOriginX / tileScale) - tileX,
+          (captureOriginY / tileScale) - tileY,
+        ];
+        const settleStarted = performance.now();
+        await setAndWaitNode2CanvasView(canvas, ds, root, graph, tileOffset, tileScale, log, {
+          settleMs: Number(options.node2TileSettleMs) || NODE2_TILE_SETTLE_MS,
+        });
+        const settleElapsedMs = Math.round(performance.now() - settleStarted);
+        logStep(log, "capture.tile.view", () => ({
+          row,
+          col,
+          tileX,
+          tileY,
+          scale: ds.scale,
+          offset: [ds.offset[0], ds.offset[1]],
+          rawNodeRects: snapshotNode2RawRects(root, 4),
+          domGraphBBox: measureNode2DomGraphBBox(root, ds),
+        }));
+
+        const frameStarted = performance.now();
+        const frame = await captureFrameFromPreparedVideo(prepared, {
+          ...options,
+          frameCount: 1,
+          frameTimeoutMs: 5000,
+          probe: false,
+          pollChangedFrame: true,
+          pollMinWaitMs: Number(options.node2TilePollMinWaitMs) || NODE2_TILE_POLL_MIN_WAIT_MS,
+          pollIntervalMs: Number(options.node2TilePollIntervalMs) || NODE2_TILE_POLL_INTERVAL_MS,
+        }, log);
+        const frameElapsedMs = Math.round(performance.now() - frameStarted);
+        if (frame.error || !frame.canvas) {
+          return {
+            error: frame.error || { message: "Node 2.0 tiled capture failed: no captured frame." },
+          };
+        }
+        const tileLeft = tileX;
+        const tileTop = tileY;
+        const tileRight = tileX + visibleGraphWidth;
+        const tileBottom = tileY + visibleGraphHeight;
+        const cellLeft = col === 0 ? minX : minX + col * tileStepX;
+        const cellTop = row === 0 ? minY : minY + row * tileStepY;
+        const cellRight = col === cols - 1 ? maxX : Math.min(maxX, minX + (col + 1) * tileStepX);
+        const cellBottom = row === rows - 1 ? maxY : Math.min(maxY, minY + (row + 1) * tileStepY);
+        const drawLeft = Math.max(cellLeft, tileLeft);
+        const drawTop = Math.max(cellTop, tileTop);
+        const drawRight = Math.min(cellRight, tileRight);
+        const drawBottom = Math.min(cellBottom, tileBottom);
+        if (drawRight <= drawLeft || drawBottom <= drawTop) {
+          releaseCanvasResource(frame.canvas);
+          continue;
+        }
+
+        const sx = Math.max(0, Math.floor((drawLeft - tileLeft) * pxPerGraphX));
+        const sy = Math.max(0, Math.floor((drawTop - tileTop) * pxPerGraphY));
+        const sw = Math.max(1, Math.min(frame.canvas.width - sx, Math.ceil((drawRight - drawLeft) * pxPerGraphX)));
+        const sh = Math.max(1, Math.min(frame.canvas.height - sy, Math.ceil((drawBottom - drawTop) * pxPerGraphY)));
+        const dx = Math.round((drawLeft - minX) * pxPerGraphX);
+        const dy = Math.round((drawTop - minY) * pxPerGraphY);
+        const dw = Math.max(1, Math.round((drawRight - drawLeft) * pxPerGraphX));
+        const dh = Math.max(1, Math.round((drawBottom - drawTop) * pxPerGraphY));
+        outputCtx.drawImage(frame.canvas, sx, sy, sw, sh, dx, dy, dw, dh);
+        releaseCanvasResource(frame.canvas);
+        logStep(log, "capture.tile.blit", () => ({
+          row,
+          col,
+          source: { sx, sy, sw, sh },
+          dest: { dx, dy, dw, dh },
+          pxPerGraph: { x: pxPerGraphX, y: pxPerGraphY },
+          drawGraphRect: { left: drawLeft, top: drawTop, right: drawRight, bottom: drawBottom },
+          cellGraphRect: { left: cellLeft, top: cellTop, right: cellRight, bottom: cellBottom },
+          tileGraphRect: { left: tileLeft, top: tileTop, right: tileRight, bottom: tileBottom },
+          actualTransform: { scale: ds.scale, offset: [ds.offset[0], ds.offset[1]] },
+          elapsedMs: Math.round(performance.now() - tileStarted),
+          settleElapsedMs,
+          frameElapsedMs,
+        }));
+      }
+    }
+    options.onProgress?.({ value: 1, percent: 100 });
+
+    return {
+      type: "raster",
+      canvas: output,
+      frame: {
+        blobOk: Boolean(output),
+        width: output?.width || 0,
+        height: output?.height || 0,
+        tiled: true,
+        cols,
+        rows,
+        tileScale,
+      },
+      fit: {
+        ...fitInfo,
+        tiled: {
+          cols,
+          rows,
+          tileScale,
+          outputWidth: output?.width || 0,
+          outputHeight: output?.height || 0,
+        },
+      },
+      restriction: { attempted: "restriction", ok: true },
+    };
+  } catch (error) {
+    return {
+      error: {
+        name: error?.name || "",
+        message: error?.message || String(error),
+      },
+    };
+  } finally {
+    interactionShield?.remove();
+    releaseHiddenVideo(prepared?.video);
+    stopStream(stream);
+    chromeHider.restore();
+    canvasInfoHider.restore();
+    document.documentElement.classList.remove("cwie-node2-capturing");
+    setNode2CanvasView(canvas, ds, saved.offset, saved.scale);
+    await waitForNode2CameraSettle(120);
+  }
+}
+
 function toBlob(canvas, mime) {
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
@@ -887,66 +2038,123 @@ function collectNode2Warnings(options = {}) {
   if (Number(options.nodeOpacity) < 100) {
     warnings.push("node2:node_opacity_unsupported");
   }
-  if (options.exceedMode === "tile") {
-    warnings.push("node2:tiled_export_unsupported");
-  }
   return warnings;
 }
 
 export async function captureNode2(options = {}) {
-  const format = String(options.format || "png").toLowerCase();
-  const mime = format === "webp" ? "image/webp" : "image/png";
-  const report = await withFitNode2View(options, async (fitInfo) => {
-    logStep(options.debug ? console.log : null, "capture.fit", fitInfo);
-    const captured = await runNode2CaptureFrameSpike({
-      ...options,
-      target: options.target || "commonRoot",
-      includeCanvas: true,
-      frameCount: 1,
-      frameTimeoutMs: 250,
-      probe: false,
-      log: options.debug ? console.log : null,
-    });
-    if (captured.canvas && fitInfo) {
-      captured.canvas = cropNode2CanvasToFit(captured.canvas, fitInfo);
-      captured.frame = {
-        ...captured.frame,
-        croppedWidth: captured.canvas.width,
-        croppedHeight: captured.canvas.height,
-      };
-      captured.fit = fitInfo;
-      logStep(options.debug ? console.log : null, "capture.crop", {
+  if (node2CaptureInFlight) {
+    throw new Error("Node 2.0 capture is already running.");
+  }
+  node2CaptureInFlight = true;
+  try {
+    const format = String(options.format || "png").toLowerCase();
+    const mime = format === "webp" ? "image/webp" : "image/png";
+    const root = getNode2Layers().root;
+    const tileInfo = getNode2CurrentGraphBBox();
+    let report = null;
+    if (shouldUseNode2TiledCapture(options, tileInfo, root)) {
+      logStep(options.debug ? console.log : null, "capture.tile.start", {
         version: NODE2_CAPTURE_VERSION,
-        croppedWidth: captured.canvas.width,
-        croppedHeight: captured.canvas.height,
-        cropRectCss: fitInfo.cropRectCss,
-        cropGeometry: fitInfo.cropGeometry,
-        bbox: fitInfo.bbox,
-        metricsAfterFit: fitInfo.metricsAfterFit,
+        bbox: tileInfo?.bbox,
+        tileScale: getNode2TileScale(options),
+      });
+      const tiled = await captureNode2TiledFromFit(tileInfo, options);
+      if (tiled?.canvas && !tiled.error) {
+        logStep(options.debug ? console.log : null, "capture.tile.done", {
+          version: NODE2_CAPTURE_VERSION,
+          frame: tiled.frame,
+          fit: tiled.fit?.tiled,
+        });
+        report = tiled;
+      } else {
+        logStep(options.debug ? console.log : null, "capture.tile.failed", {
+          version: NODE2_CAPTURE_VERSION,
+          error: tiled?.error || null,
+        });
+        throw new Error(`Node 2.0 tiled capture failed: ${tiled?.error?.message || "unknown error"}`);
+      }
+    } else if (options.node2TiledCapture === true || options.exceedMode === "tile") {
+      logStep(options.debug ? console.log : null, "capture.tile.skip", {
+        version: NODE2_CAPTURE_VERSION,
+        reason: "node2_tiled_display_media_capture_unavailable",
       });
     }
-    return captured;
-  });
-  if (report.error) {
-    throw new Error(`Node 2.0 capture failed: ${report.error.message || "unknown error"}`);
+
+    if (!report) {
+      report = await withFitNode2View(options, async (fitInfo) => {
+        logStep(options.debug ? console.log : null, "capture.fit", fitInfo);
+        const captured = await captureNode2SingleFrame({
+          ...options,
+          target: options.target || "commonRoot",
+          includeCanvas: true,
+          frameCount: 1,
+          frameTimeoutMs: 250,
+          probe: false,
+          log: options.debug ? console.log : null,
+        });
+        if (captured.canvas && fitInfo) {
+          captured.canvas = cropNode2CanvasToFit(captured.canvas, fitInfo);
+          captured.frame = {
+            ...captured.frame,
+            croppedWidth: captured.canvas.width,
+            croppedHeight: captured.canvas.height,
+          };
+          captured.fit = fitInfo;
+          logStep(options.debug ? console.log : null, "capture.crop", {
+            version: NODE2_CAPTURE_VERSION,
+            croppedWidth: captured.canvas.width,
+            croppedHeight: captured.canvas.height,
+            cropRectCss: fitInfo.cropRectCss,
+            cropGeometry: fitInfo.cropGeometry,
+            bbox: fitInfo.bbox,
+            metricsAfterFit: fitInfo.metricsAfterFit,
+          });
+        }
+        return captured;
+      });
+    }
+    if (report.error) {
+      throw new Error(`Node 2.0 capture failed: ${report.error.message || "unknown error"}`);
+    }
+    if (!report.canvas || !report.frame?.blobOk) {
+      throw new Error("Node 2.0 capture failed: no captured frame was produced.");
+    }
+    logStep(options.debug ? console.log : null, "capture.encode.start", {
+      width: report.canvas.width,
+      height: report.canvas.height,
+      tiled: Boolean(report.frame?.tiled),
+      mime,
+    });
+    const width = report.canvas.width;
+    const height = report.canvas.height;
+    const blob = await toBlob(report.canvas, mime);
+    releaseCanvasResource(report.canvas);
+    report.canvas = null;
+    logStep(options.debug ? console.log : null, "capture.encode.done", {
+      size: blob.size,
+      type: blob.type,
+    });
+    const warnings = collectNode2Warnings(options);
+    if (report.restriction?.attempted && !report.restriction.ok) {
+      warnings.push(`node2:target_restriction_failed:${report.restriction.attempted}`);
+    }
+    if (report.frame?.tiled) {
+      warnings.push("node2:compositor_tiled_capture");
+    } else if (options.exceedMode === "tile") {
+      warnings.push("node2:tiled_export_unsupported");
+    }
+    return {
+      type: "raster",
+      mime,
+      blob,
+      width,
+      height,
+      cwieWarnings: warnings,
+      node2Report: report,
+    };
+  } finally {
+    node2CaptureInFlight = false;
   }
-  if (!report.canvas || !report.frame?.blobOk) {
-    throw new Error("Node 2.0 capture failed: no captured frame was produced.");
-  }
-  const blob = await toBlob(report.canvas, mime);
-  const warnings = collectNode2Warnings(options);
-  if (report.restriction?.attempted && !report.restriction.ok) {
-    warnings.push(`node2:target_restriction_failed:${report.restriction.attempted}`);
-  }
-  return {
-    type: "raster",
-    mime,
-    blob,
-    width: report.canvas.width,
-    height: report.canvas.height,
-    cwieWarnings: warnings,
-    node2Report: report,
-  };
 }
 
 async function waitAfterCameraMove() {
@@ -957,10 +2165,14 @@ async function waitAfterCameraMove() {
 }
 
 function setCanvasView(ds, offset, scale) {
+  const canvas = app?.canvas;
+  if (canvas) {
+    setNode2CanvasView(canvas, ds, offset, scale);
+    return;
+  }
+  ds.scale = scale;
   ds.offset[0] = offset[0];
   ds.offset[1] = offset[1];
-  ds.scale = scale;
-  app?.canvas?.setDirty?.(true, true);
 }
 
 export async function runNode2TileProbe(options = {}) {
@@ -981,12 +2193,14 @@ export async function runNode2TileProbe(options = {}) {
   const targetName = options.target || "commonRoot";
   const target = resolveTarget(targetName);
   const captures = [];
-  ensureSpikeStyle();
+  ensureNode2CaptureStyle();
   const captureHandle = await maybeSetCaptureHandle(log);
-  document.documentElement.classList.add("cwie-node2-capturing");
   let stream = null;
+  let interactionShield = null;
   try {
     stream = await requestDisplayMedia(log);
+    document.documentElement.classList.add("cwie-node2-capturing");
+    interactionShield = createNode2InteractionShield();
     for (let y = 0; y < tileCount; y += 1) {
       for (let x = 0; x < tileCount; x += 1) {
         setCanvasView(ds, [
@@ -1018,6 +2232,7 @@ export async function runNode2TileProbe(options = {}) {
       },
     };
   } finally {
+    interactionShield?.remove();
     stopStream(stream);
     document.documentElement.classList.remove("cwie-node2-capturing");
     setCanvasView(ds, original.offset, original.scale);
@@ -1025,11 +2240,71 @@ export async function runNode2TileProbe(options = {}) {
   }
 }
 
-export function installNode2SpikeApi(root = window.__cwie__ || {}) {
-  root.node2Spike = {
-    inspect: inspectNode2Targets,
-    captureFrame: runNode2CaptureFrameSpike,
-    tileProbe: runNode2TileProbe,
+export async function runNode2CameraMoveProbe(options = {}) {
+  const canvas = app?.canvas;
+  const ds = canvas?.ds;
+  const { root } = getNode2Layers();
+  if (!canvas?.canvas || !ds || !Array.isArray(ds.offset) || !root) {
+    return { ok: false, error: "Node 2.0 canvas/root unavailable" };
+  }
+
+  const original = {
+    offset: [ds.offset[0], ds.offset[1]],
+    scale: ds.scale || 1,
   };
-  return root.node2Spike;
+  const deltaGraphX = Number.isFinite(Number(options.deltaGraphX))
+    ? Number(options.deltaGraphX)
+    : 240;
+  const deltaGraphY = Number.isFinite(Number(options.deltaGraphY))
+    ? Number(options.deltaGraphY)
+    : 120;
+  const targetScale = Number.isFinite(Number(options.targetScale))
+    ? Math.max(0.05, Math.min(4, Number(options.targetScale)))
+    : original.scale;
+  const sampleBefore = snapshotNode2RawRects(root, 6);
+  try {
+    setNode2CanvasView(canvas, ds, [
+      original.offset[0] + deltaGraphX,
+      original.offset[1] + deltaGraphY,
+    ], targetScale);
+    await waitForNode2CameraSettle(Math.max(120, Number(options.settleMs) || 360));
+    const sampleAfter = snapshotNode2RawRects(root, 6);
+    const beforeById = new Map(sampleBefore.map((item) => [item.id, item]));
+    const deltas = sampleAfter.map((after) => {
+      const before = beforeById.get(after.id);
+      return {
+        id: after.id,
+        title: after.title,
+        dx: before?.rect && after.rect ? after.rect.left - before.rect.left : null,
+        dy: before?.rect && after.rect ? after.rect.top - before.rect.top : null,
+        widthRatio: before?.rect && after.rect && before.rect.width
+          ? after.rect.width / before.rect.width
+          : null,
+        heightRatio: before?.rect && after.rect && before.rect.height
+          ? after.rect.height / before.rect.height
+          : null,
+      };
+    });
+    return {
+      ok: true,
+      version: NODE2_CAPTURE_VERSION,
+      original,
+      applied: {
+        offset: [ds.offset[0], ds.offset[1]],
+        scale: ds.scale || 1,
+        targetScale,
+        deltaGraphX,
+        deltaGraphY,
+        expectedCssDx: deltaGraphX * targetScale,
+        expectedCssDy: deltaGraphY * targetScale,
+        expectedSizeRatio: targetScale / original.scale,
+      },
+      before: sampleBefore,
+      after: sampleAfter,
+      deltas,
+    };
+  } finally {
+    setNode2CanvasView(canvas, ds, original.offset, original.scale);
+    await waitForNode2CameraSettle(120);
+  }
 }

--- a/web/js/core/backends/node2_compositor_spike.mjs
+++ b/web/js/core/backends/node2_compositor_spike.mjs
@@ -1,0 +1,435 @@
+import { app } from "/scripts/app.js";
+
+const SPIKE_STYLE_ID = "cwie-node2-spike-style";
+
+function logStep(log, label, payload) {
+  log?.(`[CWIE][Node2Spike] ${label}`, payload);
+}
+
+function asArray(value) {
+  return Array.from(value || []);
+}
+
+function describeElement(el) {
+  if (!el) return null;
+  const rect = el.getBoundingClientRect?.();
+  return {
+    tagName: el.tagName,
+    id: el.id || "",
+    className: typeof el.className === "string" ? el.className : "",
+    testId: el.getAttribute?.("data-testid") || "",
+    rect: rect
+      ? {
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        right: rect.right,
+        bottom: rect.bottom,
+      }
+      : null,
+  };
+}
+
+function getApiSupport() {
+  const proto = typeof BrowserCaptureMediaStreamTrack !== "undefined"
+    ? BrowserCaptureMediaStreamTrack.prototype
+    : null;
+  return {
+    userAgent: navigator.userAgent,
+    isSecureContext: Boolean(window.isSecureContext),
+    displayMedia: typeof navigator.mediaDevices?.getDisplayMedia === "function",
+    captureHandleConfig: typeof navigator.mediaDevices?.setCaptureHandleConfig === "function",
+    restrictionTarget: typeof window.RestrictionTarget?.fromElement === "function",
+    restrictTo: typeof proto?.restrictTo === "function",
+    cropTarget: typeof window.CropTarget?.fromElement === "function",
+    cropTo: typeof proto?.cropTo === "function",
+    imageCapture: typeof window.ImageCapture === "function",
+    requestVideoFrameCallback: typeof HTMLVideoElement !== "undefined" &&
+      typeof HTMLVideoElement.prototype.requestVideoFrameCallback === "function",
+  };
+}
+
+function getGraphRootFromTransformPane(transformPane) {
+  let node = transformPane?.parentElement || null;
+  while (node && node !== document.body) {
+    if (node.querySelector?.("#graph-canvas") && node.querySelector?.('[data-testid="transform-pane"]')) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return document.querySelector("#graph-canvas")?.parentElement || null;
+}
+
+export function inspectNode2Targets() {
+  const graphCanvas = document.querySelector("#graph-canvas") || app?.canvas?.canvas || null;
+  const transformPane = document.querySelector('[data-testid="transform-pane"]');
+  const root = getGraphRootFromTransformPane(transformPane);
+  const siblingCanvases = root ? asArray(root.querySelectorAll("canvas")) : [];
+  const linkOverlayCanvas = siblingCanvases.find((canvas) => canvas !== graphCanvas && !canvas.id) || null;
+  const vueNodeCount = transformPane?.querySelectorAll?.("[data-node-id]")?.length || 0;
+
+  const candidates = {
+    commonRoot: root,
+    transformPane,
+    linkOverlayCanvas,
+    graphCanvas,
+  };
+
+  return {
+    api: getApiSupport(),
+    appCanvas: describeElement(app?.canvas?.canvas || null),
+    candidates: Object.fromEntries(
+      Object.entries(candidates).map(([key, value]) => [key, describeElement(value)])
+    ),
+    counts: {
+      rootCanvases: siblingCanvases.length,
+      vueNodes: vueNodeCount,
+    },
+    likelyNode2: Boolean(transformPane && linkOverlayCanvas),
+  };
+}
+
+function resolveTarget(name = "commonRoot") {
+  const graphCanvas = document.querySelector("#graph-canvas") || app?.canvas?.canvas || null;
+  const transformPane = document.querySelector('[data-testid="transform-pane"]');
+  const commonRoot = getGraphRootFromTransformPane(transformPane);
+  const siblingCanvases = commonRoot ? asArray(commonRoot.querySelectorAll("canvas")) : [];
+  const linkOverlayCanvas = siblingCanvases.find((canvas) => canvas !== graphCanvas && !canvas.id) || null;
+  const targets = {
+    commonRoot,
+    transformPane,
+    linkOverlayCanvas,
+    graphCanvas,
+  };
+  return targets[name] || commonRoot || transformPane || graphCanvas;
+}
+
+function ensureSpikeStyle() {
+  if (document.getElementById(SPIKE_STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = SPIKE_STYLE_ID;
+  style.textContent = `
+    html.cwie-node2-capturing [data-testid="selection-toolbox"],
+    html.cwie-node2-capturing [data-testid="node-searchbox-popover"],
+    html.cwie-node2-capturing .p-tooltip,
+    html.cwie-node2-capturing .p-contextmenu,
+    html.cwie-node2-capturing .litegraph.litecontextmenu,
+    html.cwie-node2-capturing .cwie-dialog-backdrop {
+      visibility: hidden !important;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function stopStream(stream) {
+  for (const track of stream?.getTracks?.() || []) {
+    track.stop();
+  }
+}
+
+async function waitVideoFrame(video, count = 2) {
+  for (let i = 0; i < count; i += 1) {
+    if (typeof video.requestVideoFrameCallback === "function") {
+      await new Promise((resolve) => video.requestVideoFrameCallback(() => resolve()));
+    } else {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    }
+  }
+}
+
+async function attachHiddenVideo(stream) {
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.autoplay = true;
+  video.style.cssText = "position:fixed;left:-10000px;top:-10000px;width:1px;height:1px;opacity:0;pointer-events:none;";
+  video.srcObject = stream;
+  document.body.appendChild(video);
+  await video.play();
+  if (!video.videoWidth || !video.videoHeight) {
+    await new Promise((resolve, reject) => {
+      video.onloadedmetadata = () => resolve();
+      video.onerror = () => reject(new Error("hidden video failed to load capture stream"));
+    });
+  }
+  await waitVideoFrame(video, 2);
+  return video;
+}
+
+function drawVideoToCanvas(video) {
+  const width = Math.max(1, video.videoWidth || video.clientWidth || 1);
+  const height = Math.max(1, video.videoHeight || video.clientHeight || 1);
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d", { alpha: true, willReadFrequently: true });
+  if (!ctx) throw new Error("2d context unavailable");
+  ctx.drawImage(video, 0, 0, width, height);
+  return { canvas, ctx, width, height };
+}
+
+async function canvasProbe(canvas, ctx, width, height) {
+  const sample = ctx.getImageData(
+    Math.max(0, Math.floor(width / 2)),
+    Math.max(0, Math.floor(height / 2)),
+    1,
+    1
+  ).data;
+  const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
+  return {
+    blobOk: Boolean(blob),
+    blobType: blob?.type || null,
+    blobSize: blob?.size || 0,
+    sampleAlpha: sample[3],
+    hasAlphaChannelData: sample[3] < 255,
+  };
+}
+
+async function maybeSetCaptureHandle(log) {
+  const handle = `cwie-node2-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  if (typeof navigator.mediaDevices?.setCaptureHandleConfig !== "function") {
+    return { configured: false, handle };
+  }
+  try {
+    navigator.mediaDevices.setCaptureHandleConfig({
+      handle,
+      permittedOrigins: ["*"],
+    });
+    return { configured: true, handle };
+  } catch (error) {
+    logStep(log, "captureHandleConfig.failed", { message: error?.message || String(error) });
+    return { configured: false, handle, error: error?.message || String(error) };
+  }
+}
+
+async function requestDisplayMedia(log) {
+  const preferredOptions = {
+    preferCurrentTab: true,
+    selfBrowserSurface: "include",
+    surfaceSwitching: "exclude",
+    audio: false,
+    video: true,
+  };
+  try {
+    return await navigator.mediaDevices.getDisplayMedia(preferredOptions);
+  } catch (error) {
+    if (error?.name !== "TypeError") {
+      throw error;
+    }
+    logStep(log, "displayMedia.preferredOptions.failed", {
+      name: error.name,
+      message: error.message,
+    });
+    return navigator.mediaDevices.getDisplayMedia({ audio: false, video: true });
+  }
+}
+
+async function captureFrameFromStream(stream, target, targetName, captureHandle, options, log) {
+  const report = {
+    startedAt: new Date().toISOString(),
+    targetName,
+    before: inspectNode2Targets(),
+    captureHandle,
+    track: null,
+    restriction: null,
+    frame: null,
+  };
+
+  const [track] = stream.getVideoTracks();
+  const settings = track?.getSettings?.() || {};
+  const captureHandleInfo = track?.getCaptureHandle?.() || null;
+  report.track = {
+    label: track?.label || "",
+    settings,
+    captureHandle: captureHandleInfo,
+    isLikelySelfCapture: captureHandleInfo?.handle === captureHandle.handle ||
+      settings.displaySurface === "browser",
+  };
+  logStep(log, "displayMedia.ok", report.track);
+
+  report.restriction = await applyTargetRestriction(track, target, {
+    prefer: options.prefer || "restriction",
+    log,
+  });
+  logStep(log, "target.apply", report.restriction);
+
+  const video = await attachHiddenVideo(stream);
+  try {
+    const { canvas, ctx, width, height } = drawVideoToCanvas(video);
+    const probe = await canvasProbe(canvas, ctx, width, height);
+    report.frame = {
+      width,
+      height,
+      dpr: window.devicePixelRatio || 1,
+      ...probe,
+    };
+    logStep(log, "frame.ok", report.frame);
+    return report;
+  } finally {
+    video.remove();
+  }
+}
+
+async function applyTargetRestriction(track, target, { prefer = "restriction", log } = {}) {
+  const result = {
+    target: describeElement(target),
+    attempted: null,
+    ok: false,
+    error: null,
+  };
+  if (!target) {
+    result.error = "target not found";
+    return result;
+  }
+
+  const canRestrict =
+    prefer !== "crop" &&
+    typeof window.RestrictionTarget?.fromElement === "function" &&
+    typeof track.restrictTo === "function";
+  if (canRestrict) {
+    result.attempted = "restriction";
+    try {
+      const restrictionTarget = await window.RestrictionTarget.fromElement(target);
+      await track.restrictTo(restrictionTarget);
+      result.ok = true;
+      return result;
+    } catch (error) {
+      result.error = error?.message || String(error);
+      logStep(log, "restrict.failed", result);
+    }
+  }
+
+  const canCrop =
+    typeof window.CropTarget?.fromElement === "function" &&
+    typeof track.cropTo === "function";
+  if (canCrop) {
+    result.attempted = result.attempted ? `${result.attempted}->crop` : "crop";
+    try {
+      const cropTarget = await window.CropTarget.fromElement(target);
+      await track.cropTo(cropTarget);
+      result.ok = true;
+      return result;
+    } catch (error) {
+      result.error = error?.message || String(error);
+      logStep(log, "crop.failed", result);
+    }
+  }
+
+  if (!result.attempted) {
+    result.error = "RestrictionTarget/restrictTo and CropTarget/cropTo are unavailable";
+  }
+  return result;
+}
+
+export async function runNode2CaptureFrameSpike(options = {}) {
+  const log = options.log || console.log;
+  const targetName = options.target || "commonRoot";
+  const target = resolveTarget(targetName);
+  const report = { startedAt: new Date().toISOString(), targetName, before: inspectNode2Targets() };
+
+  ensureSpikeStyle();
+  const captureHandle = await maybeSetCaptureHandle(log);
+  document.documentElement.classList.add("cwie-node2-capturing");
+
+  let stream = null;
+  try {
+    stream = await requestDisplayMedia(log);
+    return await captureFrameFromStream(stream, target, targetName, captureHandle, options, log);
+  } catch (error) {
+    report.error = {
+      name: error?.name || "",
+      message: error?.message || String(error),
+    };
+    logStep(log, "failed", report.error);
+    return report;
+  } finally {
+    stopStream(stream);
+    document.documentElement.classList.remove("cwie-node2-capturing");
+  }
+}
+
+async function waitAfterCameraMove() {
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise((resolve) => setTimeout(resolve, 280));
+  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function setCanvasView(ds, offset, scale) {
+  ds.offset[0] = offset[0];
+  ds.offset[1] = offset[1];
+  ds.scale = scale;
+  app?.canvas?.setDirty?.(true, true);
+}
+
+export async function runNode2TileProbe(options = {}) {
+  const log = options.log || console.log;
+  const canvas = app?.canvas;
+  const ds = canvas?.ds;
+  if (!canvas?.canvas || !ds || !Array.isArray(ds.offset)) {
+    return { ok: false, error: "app.canvas.ds unavailable" };
+  }
+  const original = {
+    offset: [ds.offset[0], ds.offset[1]],
+    scale: ds.scale || 1,
+  };
+  const tileCount = Math.max(1, Math.min(3, Number(options.tiles) || 2));
+  const viewport = canvas.canvas.getBoundingClientRect();
+  const stepX = viewport.width / original.scale;
+  const stepY = viewport.height / original.scale;
+  const targetName = options.target || "commonRoot";
+  const target = resolveTarget(targetName);
+  const captures = [];
+  ensureSpikeStyle();
+  const captureHandle = await maybeSetCaptureHandle(log);
+  document.documentElement.classList.add("cwie-node2-capturing");
+  let stream = null;
+  try {
+    stream = await requestDisplayMedia(log);
+    for (let y = 0; y < tileCount; y += 1) {
+      for (let x = 0; x < tileCount; x += 1) {
+        setCanvasView(ds, [
+          original.offset[0] - x * stepX,
+          original.offset[1] - y * stepY,
+        ], original.scale);
+        await waitAfterCameraMove();
+        const frame = await captureFrameFromStream(
+          stream,
+          target,
+          targetName,
+          captureHandle,
+          options,
+          log
+        );
+        captures.push({ x, y, frame });
+      }
+    }
+    return { ok: true, original, viewport: describeElement(canvas.canvas), captures };
+  } catch (error) {
+    return {
+      ok: false,
+      original,
+      viewport: describeElement(canvas.canvas),
+      captures,
+      error: {
+        name: error?.name || "",
+        message: error?.message || String(error),
+      },
+    };
+  } finally {
+    stopStream(stream);
+    document.documentElement.classList.remove("cwie-node2-capturing");
+    setCanvasView(ds, original.offset, original.scale);
+    await waitAfterCameraMove();
+  }
+}
+
+export function installNode2SpikeApi(root = window.__cwie__ || {}) {
+  root.node2Spike = {
+    inspect: inspectNode2Targets,
+    captureFrame: runNode2CaptureFrameSpike,
+    tileProbe: runNode2TileProbe,
+  };
+  return root.node2Spike;
+}

--- a/web/js/core/backends/node2_compositor_spike.mjs
+++ b/web/js/core/backends/node2_compositor_spike.mjs
@@ -203,7 +203,6 @@ async function attachHiddenVideo(stream, log) {
     videoWidth: video.videoWidth,
     videoHeight: video.videoHeight,
   });
-  await waitVideoFrame(video, 2, log);
   return video;
 }
 
@@ -298,14 +297,14 @@ async function captureFrameFromStream(stream, target, targetName, captureHandle,
   };
   logStep(log, "displayMedia.ok", report.track);
 
-  report.restriction = await applyTargetRestriction(track, target, {
-    prefer: options.prefer || "restriction",
-    log,
-  });
-  logStep(log, "target.apply", report.restriction);
-
   const video = await attachHiddenVideo(stream, log);
   try {
+    report.restriction = await applyTargetRestriction(track, target, {
+      prefer: options.prefer || "restriction",
+      log,
+    });
+    logStep(log, "target.apply", report.restriction);
+    await waitVideoFrame(video, 2, log);
     const { canvas, ctx, width, height } = drawVideoToCanvas(video);
     const probe = await canvasProbe(canvas, ctx, width, height);
     report.frame = {
@@ -315,6 +314,13 @@ async function captureFrameFromStream(stream, target, targetName, captureHandle,
       ...probe,
     };
     logStep(log, "frame.ok", report.frame);
+    return report;
+  } catch (error) {
+    report.error = {
+      name: error?.name || "",
+      message: error?.message || String(error),
+    };
+    logStep(log, "frame.failed", report.error);
     return report;
   } finally {
     video.remove();

--- a/web/js/core/backends/node2_compositor_spike.mjs
+++ b/web/js/core/backends/node2_compositor_spike.mjs
@@ -128,17 +128,63 @@ function stopStream(stream) {
   }
 }
 
-async function waitVideoFrame(video, count = 2) {
-  for (let i = 0; i < count; i += 1) {
-    if (typeof video.requestVideoFrameCallback === "function") {
-      await new Promise((resolve) => video.requestVideoFrameCallback(() => resolve()));
-    } else {
-      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
-    }
+function timeoutError(label, timeoutMs) {
+  return new Error(`${label} timed out after ${timeoutMs}ms`);
+}
+
+async function withTimeout(promise, label, timeoutMs = 3000) {
+  let timer = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(timeoutError(label, timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 
-async function attachHiddenVideo(stream) {
+async function waitVideoMetadata(video, log) {
+  if (video.readyState >= HTMLMediaElement.HAVE_METADATA && video.videoWidth && video.videoHeight) {
+    return;
+  }
+  logStep(log, "video.metadata.wait", {
+    readyState: video.readyState,
+    videoWidth: video.videoWidth,
+    videoHeight: video.videoHeight,
+  });
+  await withTimeout(new Promise((resolve, reject) => {
+    video.addEventListener("loadedmetadata", () => resolve(), { once: true });
+    video.addEventListener("resize", () => {
+      if (video.videoWidth && video.videoHeight) resolve();
+    }, { once: true });
+    video.addEventListener("error", () => {
+      reject(new Error(video.error?.message || "hidden video failed to load capture stream"));
+    }, { once: true });
+  }), "hidden video metadata");
+}
+
+async function waitVideoFrame(video, count = 2, log) {
+  for (let i = 0; i < count; i += 1) {
+    if (typeof video.requestVideoFrameCallback === "function") {
+      await withTimeout(new Promise((resolve) => {
+        video.requestVideoFrameCallback(() => resolve());
+      }), `video frame ${i + 1}`);
+    } else {
+      await withTimeout(new Promise((resolve) => requestAnimationFrame(() => resolve())), `animation frame ${i + 1}`);
+    }
+    logStep(log, "video.frame.waited", {
+      frame: i + 1,
+      readyState: video.readyState,
+      videoWidth: video.videoWidth,
+      videoHeight: video.videoHeight,
+    });
+  }
+}
+
+async function attachHiddenVideo(stream, log) {
   const video = document.createElement("video");
   video.muted = true;
   video.playsInline = true;
@@ -146,14 +192,18 @@ async function attachHiddenVideo(stream) {
   video.style.cssText = "position:fixed;left:-10000px;top:-10000px;width:1px;height:1px;opacity:0;pointer-events:none;";
   video.srcObject = stream;
   document.body.appendChild(video);
-  await video.play();
-  if (!video.videoWidth || !video.videoHeight) {
-    await new Promise((resolve, reject) => {
-      video.onloadedmetadata = () => resolve();
-      video.onerror = () => reject(new Error("hidden video failed to load capture stream"));
-    });
-  }
-  await waitVideoFrame(video, 2);
+  logStep(log, "video.attach", {
+    readyState: video.readyState,
+    paused: video.paused,
+  });
+  await waitVideoMetadata(video, log);
+  await withTimeout(video.play(), "hidden video play");
+  logStep(log, "video.play.ok", {
+    readyState: video.readyState,
+    videoWidth: video.videoWidth,
+    videoHeight: video.videoHeight,
+  });
+  await waitVideoFrame(video, 2, log);
   return video;
 }
 
@@ -254,7 +304,7 @@ async function captureFrameFromStream(stream, target, targetName, captureHandle,
   });
   logStep(log, "target.apply", report.restriction);
 
-  const video = await attachHiddenVideo(stream);
+  const video = await attachHiddenVideo(stream, log);
   try {
     const { canvas, ctx, width, height } = drawVideoToCanvas(video);
     const probe = await canvasProbe(canvas, ctx, width, height);

--- a/web/js/core/backends/node2_compositor_spike.mjs
+++ b/web/js/core/backends/node2_compositor_spike.mjs
@@ -169,9 +169,23 @@ async function waitVideoMetadata(video, log) {
 async function waitVideoFrame(video, count = 2, log) {
   for (let i = 0; i < count; i += 1) {
     if (typeof video.requestVideoFrameCallback === "function") {
-      await withTimeout(new Promise((resolve) => {
-        video.requestVideoFrameCallback(() => resolve());
-      }), `video frame ${i + 1}`);
+      try {
+        await withTimeout(new Promise((resolve) => {
+          video.requestVideoFrameCallback(() => resolve());
+        }), `video frame ${i + 1}`);
+      } catch (error) {
+        if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || !video.videoWidth || !video.videoHeight) {
+          throw error;
+        }
+        logStep(log, "video.frame.fallback", {
+          frame: i + 1,
+          message: error?.message || String(error),
+          readyState: video.readyState,
+          videoWidth: video.videoWidth,
+          videoHeight: video.videoHeight,
+        });
+        await withTimeout(new Promise((resolve) => requestAnimationFrame(() => resolve())), `animation frame fallback ${i + 1}`);
+      }
     } else {
       await withTimeout(new Promise((resolve) => requestAnimationFrame(() => resolve())), `animation frame ${i + 1}`);
     }

--- a/web/js/core/capture/index.mjs
+++ b/web/js/core/capture/index.mjs
@@ -1,6 +1,7 @@
 import { app } from "/scripts/app.js";
 import { detectBackend } from "../detect.mjs";
 import { captureLegacy } from "../backends/legacy_capture.mjs";
+import { captureNode2 } from "../backends/node2_compositor_capture.mjs";
 import { applyBackground, downscaleIfNeeded } from "../postprocess/raster.mjs";
 import { exportWorkflowPng } from "../../export/index.mjs";
 import { embedWorkflowInPngBlob } from "../../export/png_embed_workflow.mjs";
@@ -63,9 +64,7 @@ export async function capture(options = {}) {
 
   let result;
   if (backend === "node2") {
-    const error = new Error("Node2.0 is not supported yet.");
-    error.code = NODE2_UNSUPPORTED_CODE;
-    throw error;
+    result = await captureNode2(normalized);
   } else if (normalized.format === "png" || normalized.format === "webp") {
     const selectedNodeIds = Array.isArray(normalized.selectedNodeIds)
       ? normalized.selectedNodeIds

--- a/web/js/core/detect.mjs
+++ b/web/js/core/detect.mjs
@@ -35,6 +35,16 @@ export function getLegacyCanvasMenuHook() {
 }
 
 export function detectBackend() {
+  if (typeof document !== "undefined") {
+    const transformPane = document.querySelector?.('[data-testid="transform-pane"]');
+    const graphCanvas = document.querySelector?.("#graph-canvas");
+    const root = transformPane?.closest?.("#graph-canvas-container") ||
+      transformPane?.parentElement;
+    const rootCanvases = root?.querySelectorAll?.("canvas")?.length || 0;
+    if (transformPane && graphCanvas && rootCanvases >= 2) {
+      return "node2";
+    }
+  }
   return "legacy";
 }
 

--- a/web/js/core/download.mjs
+++ b/web/js/core/download.mjs
@@ -20,6 +20,6 @@ export async function triggerDownload({ dataUrl, blob, filename }) {
   link.remove();
 
   if (revoke) {
-    setTimeout(() => URL.revokeObjectURL(revoke), 0);
+    setTimeout(() => URL.revokeObjectURL(revoke), 15_000);
   }
 }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -67,15 +67,15 @@ function installNode2SpikeApi() {
   const root = window.__cwie__ || {};
   root.node2Spike = {
     async inspect() {
-      const mod = await import("./core/backends/node2_compositor_spike.mjs");
+      const mod = await import("./core/backends/node2_compositor_capture.mjs");
       return mod.inspectNode2Targets();
     },
     async captureFrame(options = {}) {
-      const mod = await import("./core/backends/node2_compositor_spike.mjs");
+      const mod = await import("./core/backends/node2_compositor_capture.mjs");
       return mod.runNode2CaptureFrameSpike(options);
     },
     async tileProbe(options = {}) {
-      const mod = await import("./core/backends/node2_compositor_spike.mjs");
+      const mod = await import("./core/backends/node2_compositor_capture.mjs");
       return mod.runNode2TileProbe(options);
     },
   };

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -2,7 +2,23 @@ import { app } from "/scripts/app.js";
 import { installLegacyCanvasMenuItem } from "./core/menu.mjs";
 import { registerLegacySettings } from "./core/settings.mjs";
 
-let debugEnabled = localStorage.getItem("cwie.debug") === "1";
+const DEBUG_STORAGE_KEY = "cwie.debug";
+const DEBUG_SESSION_KEY = "cwie.debug.session";
+
+function getInitialDebugEnabled() {
+  try {
+    localStorage.removeItem(DEBUG_STORAGE_KEY);
+  } catch (_) {
+    // Ignore storage failures. Debug should stay opt-in and non-persistent.
+  }
+  try {
+    return sessionStorage.getItem(DEBUG_SESSION_KEY) === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
+let debugEnabled = getInitialDebugEnabled();
 let usedOfficialMenu = false;
 
 function log(...args) {
@@ -13,7 +29,12 @@ function log(...args) {
 
 function setDebug(enabled) {
   debugEnabled = !!enabled;
-  localStorage.setItem("cwie.debug", debugEnabled ? "1" : "0");
+  try {
+    localStorage.removeItem(DEBUG_STORAGE_KEY);
+    sessionStorage.setItem(DEBUG_SESSION_KEY, debugEnabled ? "1" : "0");
+  } catch (_) {
+    // Storage can be unavailable in restricted contexts; keep runtime state only.
+  }
   if (window.__cwie__) {
     window.__cwie__.debug = debugEnabled;
   }
@@ -37,15 +58,6 @@ function buildMenuLabel() {
   `;
 }
 
-let dialogPreloaded = false;
-function preloadDialogModule() {
-  if (dialogPreloaded) return;
-  dialogPreloaded = true;
-  import("./ui/dialog.mjs").catch(() => {
-    // ignore preload errors
-  });
-}
-
 async function openDialog(log) {
   try {
     const mod = await import("./ui/dialog.mjs");
@@ -63,22 +75,28 @@ async function openDialog(log) {
   }
 }
 
-function installNode2SpikeApi() {
+function installNode2DebugApi() {
   const root = window.__cwie__ || {};
-  root.node2Spike = {
+  const api = {
     async inspect() {
       const mod = await import("./core/backends/node2_compositor_capture.mjs");
       return mod.inspectNode2Targets();
     },
     async captureFrame(options = {}) {
       const mod = await import("./core/backends/node2_compositor_capture.mjs");
-      return mod.runNode2CaptureFrameSpike(options);
+      return mod.captureNode2SingleFrame(options);
     },
     async tileProbe(options = {}) {
       const mod = await import("./core/backends/node2_compositor_capture.mjs");
       return mod.runNode2TileProbe(options);
     },
+    async cameraMoveProbe(options = {}) {
+      const mod = await import("./core/backends/node2_compositor_capture.mjs");
+      return mod.runNode2CameraMoveProbe(options);
+    },
   };
+  root.node2Capture = api;
+  root.node2Spike = api;
   window.__cwie__ = root;
 }
 
@@ -90,15 +108,9 @@ app.registerExtension({
       debug: debugEnabled,
       setDebug,
     };
-    installNode2SpikeApi();
+    installNode2DebugApi();
     log("extension loaded", window.__cwie__);
     registerLegacySettings(log);
-    // Preload dialog module on idle to reduce first-open latency.
-    if ("requestIdleCallback" in window) {
-      window.requestIdleCallback(() => preloadDialogModule(), { timeout: 2000 });
-    } else {
-      setTimeout(() => preloadDialogModule(), 800);
-    }
     setTimeout(() => {
       if (usedOfficialMenu) {
         return;

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -63,6 +63,25 @@ async function openDialog(log) {
   }
 }
 
+function installNode2SpikeApi() {
+  const root = window.__cwie__ || {};
+  root.node2Spike = {
+    async inspect() {
+      const mod = await import("./core/backends/node2_compositor_spike.mjs");
+      return mod.inspectNode2Targets();
+    },
+    async captureFrame(options = {}) {
+      const mod = await import("./core/backends/node2_compositor_spike.mjs");
+      return mod.runNode2CaptureFrameSpike(options);
+    },
+    async tileProbe(options = {}) {
+      const mod = await import("./core/backends/node2_compositor_spike.mjs");
+      return mod.runNode2TileProbe(options);
+    },
+  };
+  window.__cwie__ = root;
+}
+
 app.registerExtension({
   name: "comfyui.workflowImageExport",
   setup() {
@@ -71,6 +90,7 @@ app.registerExtension({
       debug: debugEnabled,
       setDebug,
     };
+    installNode2SpikeApi();
     log("extension loaded", window.__cwie__);
     registerLegacySettings(log);
     // Preload dialog module on idle to reduce first-open latency.

--- a/web/js/ui/dialog.mjs
+++ b/web/js/ui/dialog.mjs
@@ -564,6 +564,14 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
       window.cancelIdleCallback(previewIdle);
       previewIdle = null;
     }
+    if (webpCheckTimer) {
+      clearTimeout(webpCheckTimer);
+      webpCheckTimer = null;
+    }
+    if (webpCheckIdle && "cancelIdleCallback" in window) {
+      window.cancelIdleCallback(webpCheckIdle);
+      webpCheckIdle = null;
+    }
     previewQueued = false;
     previewBusy = false;
     previewSnapshot = null;
@@ -871,7 +879,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     updateScopeAvailability();
     updateStateFromControls();
     const isRasterExport = state.format === "png" || state.format === "webp";
-    const expectsTiling = !isRasterExport && state.exceedMode === "tile";
+    const expectsTiling = (!isRasterExport || isNode2Backend) && state.exceedMode === "tile";
     if (expectsTiling) {
       exportButton.classList.add("is-progressing");
       exportProgressText.textContent = "0%";
@@ -881,9 +889,13 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     await new Promise((resolve) => requestAnimationFrame(resolve));
     logExportPhase("ui.ready");
     let messageDialogPayload = null;
+    let dialogClosed = false;
     try {
       let blob;
       if (isNode2Backend) {
+        closeDialog();
+        dialogClosed = true;
+        logExportPhase("dialog.closed.beforeNode2Capture");
         logExportPhase("capture.node2.start");
         blob = await capture({
           ...state,
@@ -891,7 +903,8 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
           padding: 0,
           nodeOpacity: 100,
           scopeSelected: false,
-          exceedMode: "downscale",
+          exceedMode: state.exceedMode,
+          node2TiledCapture: state.exceedMode === "tile",
           onProgress: updateExportProgress,
         });
         logExportPhase("capture.node2.done");
@@ -926,6 +939,11 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
           onProgress: updateExportProgress,
         });
         logExportPhase("capture.done");
+      }
+      if (!dialogClosed) {
+        closeDialog();
+        dialogClosed = true;
+        logExportPhase("dialog.closed.beforeDownload");
       }
       setDefaultsInSettings(state);
       try {
@@ -967,8 +985,10 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
       exportProgressText.textContent = "0%";
       exportButton.classList.remove("is-busy");
       onExportFinished?.();
-      closeDialog();
-      logExportPhase("dialog.closed");
+      if (!dialogClosed) {
+        closeDialog();
+        logExportPhase("dialog.closed");
+      }
       setTimeout(() => logExportPhase("post.0ms"), 0);
       setTimeout(() => logExportPhase("post.250ms"), 250);
       setTimeout(() => logExportPhase("post.1000ms"), 1000);

--- a/web/js/ui/dialog.mjs
+++ b/web/js/ui/dialog.mjs
@@ -160,7 +160,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   });
 
   const dialog = document.createElement("div");
-  dialog.className = "cwie-dialog";
+  dialog.className = isNode2Backend ? "cwie-dialog is-node2-backend" : "cwie-dialog";
 
   const title = document.createElement("h3");
   title.textContent = "Export Workflow Image";
@@ -207,10 +207,20 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   basicTitle.textContent = "Basic";
 
   const backendNote = document.createElement("div");
-  backendNote.className = "cwie-note";
-  backendNote.textContent = isNode2Backend
-    ? "Node 2.0 export captures the visible graph view when you press Export."
-    : "";
+  backendNote.className = isNode2Backend ? "cwie-backend-note node2" : "cwie-note";
+  if (isNode2Backend) {
+    backendNote.innerHTML = `
+      <div class="cwie-backend-note-head">
+        <span class="cwie-backend-pill">Node 2.0</span>
+        <span>Compositor capture mode</span>
+      </div>
+      <div class="cwie-backend-note-body">
+        Captures the live graph on Export using Chromium's compositor capture APIs. Format, workflow embedding, and solid background still apply.
+      </div>
+    `;
+  } else {
+    backendNote.textContent = "";
+  }
 
   const formatSelect = createSelect("format", [
     { value: "png", label: "PNG" },
@@ -223,11 +233,17 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   const webpNote = document.createElement("div");
   webpNote.className = "cwie-note";
 
-  const backgroundGroup = createRadioGroup("cwie-bg", [
-    { value: "ui", label: "UI" },
-    { value: "transparent", label: "Transparent" },
-    { value: "solid", label: "Solid" },
-  ]);
+  const backgroundOptions = isNode2Backend
+    ? [
+      { value: "ui", label: "UI" },
+      { value: "solid", label: "Solid" },
+    ]
+    : [
+      { value: "ui", label: "UI" },
+      { value: "transparent", label: "Transparent" },
+      { value: "solid", label: "Solid" },
+    ];
+  const backgroundGroup = createRadioGroup("cwie-bg", backgroundOptions);
 
   const solidColorInput = document.createElement("input");
   solidColorInput.type = "color";
@@ -307,6 +323,15 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
 
   const advancedBody = document.createElement("div");
   advancedBody.className = "cwie-advanced-body";
+
+  function markNode2UnsupportedRow(row, reason) {
+    if (!isNode2Backend || !row) return row;
+    row.classList.add("is-node2-disabled");
+    row.setAttribute("aria-disabled", "true");
+    row.dataset.node2Reason = reason;
+    row.title = reason;
+    return row;
+  }
 
   const pngCompressionInput = document.createElement("input");
   pngCompressionInput.type = "range";
@@ -440,7 +465,8 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     formatSelect.setValue(nextState.format);
     embedToggle.input.checked = nextState.embedWorkflow;
     syncEmbedAvailability(nextState.format);
-    const bgInput = backgroundGroup.inputs.get(nextState.background);
+    const background = backgroundGroup.inputs.has(nextState.background) ? nextState.background : "ui";
+    const bgInput = backgroundGroup.inputs.get(background);
     if (bgInput) {
       bgInput.checked = true;
     }
@@ -455,28 +481,24 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     maxLongEdgeInput.value = String(nextState.maxLongEdge);
     exceedSelect.setValue(nextState.exceedMode);
     if (solidColorRow) {
-      solidColorRow.classList.toggle("is-hidden", nextState.background !== "solid");
+      solidColorRow.classList.toggle("is-hidden", background !== "solid");
     }
     scopeToggle.input.checked = Boolean(nextState.scopeSelected);
     const opacityValue = Number.isFinite(Number(nextState.scopeOpacity)) ? nextState.scopeOpacity : 40;
     scopeOpacityInput.value = String(opacityValue);
     scopeOpacityValue.textContent = String(opacityValue);
-    previewFrame.classList.toggle("is-transparent", nextState.background === "transparent");
+    previewFrame.classList.toggle("is-transparent", background === "transparent");
     if (debugToggle?.input) {
       debugToggle.input.checked = Boolean(nextState.debug);
     }
     if (isNode2Backend) {
       paddingInput.disabled = true;
       nodeOpacityInput.disabled = true;
+      pngCompressionInput.disabled = true;
+      maxLongEdgeInput.disabled = true;
       scopeToggle.input.disabled = true;
       scopeOpacityInput.disabled = true;
       exceedSelect.setDisabled(true);
-      const transparentInput = backgroundGroup.inputs.get("transparent");
-      if (transparentInput) transparentInput.disabled = true;
-      if (nextState.background === "transparent") {
-        const uiInput = backgroundGroup.inputs.get("ui");
-        if (uiInput) uiInput.checked = true;
-      }
     }
   }
 
@@ -495,9 +517,6 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     });
     state = {
       ...normalized,
-      background: isNode2Backend && normalized.background === "transparent"
-        ? "ui"
-        : normalized.background,
       debug: prevDebug,
       scopeSelected: Boolean(scopeToggle.input.checked),
       scopeOpacity: Number.parseInt(scopeOpacityInput.value, 10) || 0,
@@ -1018,22 +1037,46 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
 
   solidColorRow = createRow("Solid color", solidColorInput);
   controlsScroll.appendChild(solidColorRow);
-  controlsScroll.appendChild(
-    createRow("Node opacity", nodeOpacityWrapper, {
-      helpText: "Controls node background opacity in exports.",
-    })
-  );
-  controlsScroll.appendChild(createRow("Padding", paddingWrapper));
-  controlsScroll.appendChild(createRow("Scope", scopeToggle.wrapper));
-  controlsScroll.appendChild(
-    createRow("Scope opacity", scopeOpacityWrapper, {
-      helpText: "Opacity for non-selected nodes when Scope is enabled.",
-    })
-  );
+  const nodeOpacityRow = createRow("Node opacity", nodeOpacityWrapper, {
+    helpText: "Controls node background opacity in exports.",
+  });
+  controlsScroll.appendChild(markNode2UnsupportedRow(
+    nodeOpacityRow,
+    "Node opacity is only available in the legacy renderer."
+  ));
+  const paddingRow = createRow("Padding", paddingWrapper);
+  controlsScroll.appendChild(markNode2UnsupportedRow(
+    paddingRow,
+    "Padding is not applied in Node 2.0 compositor capture."
+  ));
+  const scopeRow = createRow("Scope", scopeToggle.wrapper);
+  controlsScroll.appendChild(markNode2UnsupportedRow(
+    scopeRow,
+    "Selection scope is not available in Node 2.0 compositor capture."
+  ));
+  const scopeOpacityRow = createRow("Scope opacity", scopeOpacityWrapper, {
+    helpText: "Opacity for non-selected nodes when Scope is enabled.",
+  });
+  controlsScroll.appendChild(markNode2UnsupportedRow(
+    scopeOpacityRow,
+    "Scope opacity is only available when selection scope is supported."
+  ));
 
-  advancedBody.appendChild(createRow("PNG Compression", pngCompressionWrapper));
-  advancedBody.appendChild(createRow("Max long edge", maxLongEdgeInput));
-  advancedBody.appendChild(createRow("If exceeded", exceedSelect.root));
+  const pngCompressionRow = createRow("PNG Compression", pngCompressionWrapper);
+  advancedBody.appendChild(markNode2UnsupportedRow(
+    pngCompressionRow,
+    "PNG compression level is not applied to browser compositor capture."
+  ));
+  const maxLongEdgeRow = createRow("Max long edge", maxLongEdgeInput);
+  advancedBody.appendChild(markNode2UnsupportedRow(
+    maxLongEdgeRow,
+    "Max long edge downscaling is not used for Node 2.0 tiled compositor capture."
+  ));
+  const exceedRow = createRow("If exceeded", exceedSelect.root);
+  advancedBody.appendChild(markNode2UnsupportedRow(
+    exceedRow,
+    "Node 2.0 currently uses its compositor capture path; this mode is fixed by the backend."
+  ));
 
   // Debug Toggle
   const debugToggle = createToggle();

--- a/web/js/ui/dialog.mjs
+++ b/web/js/ui/dialog.mjs
@@ -139,19 +139,17 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
 
   ensureStyles();
 
-  if (detectBackendType() === "node2") {
-    openMessageDialog({
-      title: "Node2.0 Unsupported",
-      message: "Node2.0 is not supported yet.",
-    });
-    return;
-  }
+  const backendType = detectBackendType();
+  const isNode2Backend = backendType === "node2";
 
   let state = buildInitialState({
     defaults: getDefaultsFromSettings(),
     lastUsed: loadLastUsed(),
     debugEnabled: isDebugEnabled(),
   });
+  if (isNode2Backend && state.background === "transparent") {
+    state = { ...state, background: "ui" };
+  }
 
   const backdrop = document.createElement("div");
   backdrop.className = "cwie-backdrop";
@@ -207,6 +205,12 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   const basicTitle = document.createElement("div");
   basicTitle.className = "cwie-section-title";
   basicTitle.textContent = "Basic";
+
+  const backendNote = document.createElement("div");
+  backendNote.className = "cwie-note";
+  backendNote.textContent = isNode2Backend
+    ? "Node 2.0 export captures the visible graph view when you press Export."
+    : "";
 
   const formatSelect = createSelect("format", [
     { value: "png", label: "PNG" },
@@ -461,6 +465,19 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     if (debugToggle?.input) {
       debugToggle.input.checked = Boolean(nextState.debug);
     }
+    if (isNode2Backend) {
+      paddingInput.disabled = true;
+      nodeOpacityInput.disabled = true;
+      scopeToggle.input.disabled = true;
+      scopeOpacityInput.disabled = true;
+      exceedSelect.setDisabled(true);
+      const transparentInput = backgroundGroup.inputs.get("transparent");
+      if (transparentInput) transparentInput.disabled = true;
+      if (nextState.background === "transparent") {
+        const uiInput = backgroundGroup.inputs.get("ui");
+        if (uiInput) uiInput.checked = true;
+      }
+    }
   }
 
   function updateStateFromControls() {
@@ -478,6 +495,9 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     });
     state = {
       ...normalized,
+      background: isNode2Backend && normalized.background === "transparent"
+        ? "ui"
+        : normalized.background,
       debug: prevDebug,
       scopeSelected: Boolean(scopeToggle.input.checked),
       scopeOpacity: Number.parseInt(scopeOpacityInput.value, 10) || 0,
@@ -487,6 +507,15 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   let scopeInitialized = false;
 
   function updateScopeAvailability(forceDefault = false) {
+    if (isNode2Backend) {
+      scopeToggle.input.checked = false;
+      scopeToggle.input.disabled = true;
+      scopeOpacityInput.disabled = true;
+      scopeOpacityInput.value = "40";
+      scopeOpacityValue.textContent = "40";
+      scopeInitialized = true;
+      return;
+    }
     const selectedIds = getSelectedNodeIds();
     const hasSelection = selectedIds.length > 0;
     scopeToggle.input.disabled = !hasSelection;
@@ -584,6 +613,10 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
 
   async function renderPreview(previewStateOverride = null, options = {}) {
     if (dialogClosed) return;
+    if (isNode2Backend) {
+      previewFrame.classList.remove("is-loading");
+      return null;
+    }
     if (previewPaused && !options.force) {
       previewQueued = true;
       return;
@@ -653,6 +686,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
 
   function schedulePreview(delay = 450) {
     if (dialogClosed) return;
+    if (isNode2Backend) return;
     if (previewPaused) {
       previewQueued = true;
       return;
@@ -849,7 +883,19 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     let messageDialogPayload = null;
     try {
       let blob;
-      if (state.format === "png" || state.format === "webp") {
+      if (isNode2Backend) {
+        logExportPhase("capture.node2.start");
+        blob = await capture({
+          ...state,
+          background: state.background === "transparent" ? "ui" : state.background,
+          padding: 0,
+          nodeOpacity: 100,
+          scopeSelected: false,
+          exceedMode: "downscale",
+          onProgress: updateExportProgress,
+        });
+        logExportPhase("capture.node2.done");
+      } else if (state.format === "png" || state.format === "webp") {
         const previewState = buildPreviewState();
         const previewKey = getPreviewStateKey(previewState);
         logExportPhase("preview.capture.start");
@@ -942,6 +988,9 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   footer.appendChild(webpNote);
 
   controlsScroll.appendChild(basicTitle);
+  if (backendNote.textContent) {
+    controlsScroll.appendChild(backendNote);
+  }
   controlsScroll.appendChild(createRow("Format", formatSelect.root));
   controlsScroll.appendChild(createRow("Embed workflow", embedToggle.wrapper));
   controlsScroll.appendChild(embedNote);
@@ -999,9 +1048,15 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   updateScopeAvailability(true);
   previewFrame.classList.toggle("is-transparent", state.background === "transparent");
   solidColorRow.classList.toggle("is-hidden", state.background !== "solid");
+  if (isNode2Backend) {
+    previewFrame.classList.remove("is-loading");
+    previewFrame.classList.add("is-message");
+    previewLoading.querySelector(".cwie-preview-loading-text").textContent =
+      "Node 2.0 capture runs on export.";
+  }
   // Defer first preview so the dialog paints immediately.
   setTimeout(() => {
-    if (!dialogClosed) {
+    if (!dialogClosed && !isNode2Backend) {
       schedulePreview(0);
     }
   }, 0);


### PR DESCRIPTION
## Summary

Adds the Node 2.0 compositor capture path and refines the export dialog around the constraints of that backend.

- Adds Node 2.0 compositor capture support with tiled graph capture and capture-time chrome suppression.
- Clarifies the dialog when Node 2.0 is active and dims controls that only apply to the legacy renderer.
- Limits Node 2.0 background choices to UI and Solid; Transparent remains legacy-only because browser compositor capture cannot preserve alpha.
- Implements Node 2.0 solid background replacement by temporarily mirroring ComfyUI's canvas background-image behavior without hiding the graph canvas, so links/wires remain visible.

## Validation

- node --check web/js/core/backends/node2_compositor_capture.mjs
- node --check web/js/ui/dialog.mjs
- npm test passes 15/15
- git diff --check

## Notes

This PR keeps the Node 2.0 path separate from the legacy renderer. Some legacy-only options remain visible but disabled/dimmed in Node 2.0 mode so the current backend limitations are explicit.