### PR TITLE
[codex] Update README for Node 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # ComfyUI Workflow Image Export
 
-Export clean workflow images from **ComfyUI Classic (LiteGraph)** with optional embedded JSON metadata.
+Export clean workflow images from **ComfyUI Classic (LiteGraph)** and the **ComfyUI Node 2.0 frontend** with optional embedded JSON metadata.
 
 https://github.com/user-attachments/assets/f705aae4-d082-4d68-a1be-57c0d3076327
+
+> [!IMPORTANT]
+> Node 2.0 export is not a full replacement for the Classic/LiteGraph renderer.
+> It uses Chromium browser compositor capture, so it currently requires a Chromium-based browser and cannot support every Classic option.
 
 ## Features
 - Export workflow as PNG or WebP image
 - Customizable background and padding
 - Embed workflow JSON metadata (PNG only)
 - Selection-based cropping with opacity control
+- Node 2.0 compositor capture support for current Chromium-based browsers
 
 ## Installation
 
@@ -26,10 +31,17 @@ Install via **ComfyUI Manager**:
 4. Click **Export**.
 
 ## Options (Dialog)
+
+> [!NOTE]
+> Node 2.0 mode disables or simplifies options that cannot be reproduced by browser compositor capture.
+> Transparent background, padding, selection scope, and node opacity are not available in Node 2.0 mode.
+
 - **Format**: PNG / WebP  
   - Workflow embedding is **PNG only**.
 - **Embed workflow**: include workflow JSON in PNG.
-- **Background**: UI / Transparent / Solid.
+- **Background**:
+  - Classic: UI / Transparent / Solid.
+  - Node 2.0: UI / Solid.
 - **Padding**: margin around the captured bounds (slider).
 - **Scope** (when nodes are selected):
   - **Scope** toggle: crop to selection.
@@ -38,7 +50,10 @@ Install via **ComfyUI Manager**:
   - Output resolution, max long edge, exceed behavior.
 
 ## Notes
-- Classic only. Node 2.0 / new frontend is not supported. I tried, I failed. Sorry.
+- Classic export uses the legacy LiteGraph renderer.
+- Node 2.0 export uses Chromium browser compositor capture. The browser will ask you to share the current tab/window when exporting.
+- Node 2.0 cannot preserve transparent pixels, so transparent background is Classic-only.
+- Some Classic-only controls are disabled in Node 2.0 mode because browser compositor capture cannot faithfully reproduce them.
 - Preview is a faster render path and may skip heavy things (like video thumbnails).
 - DOM-backed widgets are handled best-effort.
 - VHS previews and multiline widgets are supported in export.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workflow-image-export"
 description = "A simple ComfyUI extension to export images of your workflows with embedded JSON data."
-version = "1.0.11"
+version = "1.1.0"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
## Summary

Updates the public README and package version after the Node 2.0 compositor capture support merge.

- Describes Classic/LiteGraph and Node 2.0 frontend export support.
- Adds prominent Node 2.0 caveats: Chromium-based browser required and not full Classic renderer compatibility.
- Documents Node 2.0 unsupported options: transparent background, padding, selection scope, and node opacity.
- Bumps the project version from 1.0.11 to 1.1.0.

## Validation

- git diff --check
- python3 TOML parse check for pyproject version: 1.1.0