### PR TITLE
Guard legacy DOM media overlays from canvas taint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test tests/core/settings_state.test.js tests/core/storage.test.js tests/core/workflow_state.test.js tests/core/graph_transform.test.js tests/core/legacy_text_helpers.test.js tests/core/legacy_widget_text_fallback.test.js tests/export/limits.test.js tests/export/fallback_media_helpers.test.js tests/export/offscreen_render_utils.test.js tests/ui/state.test.js tests/ui/preview_state.test.js tests/ui/elements.test.js tests/ui/export_filename.test.js tests/ui/webp_availability.test.js tests/smoke/module_imports.test.js"
+    "test": "node --test tests/core/settings_state.test.js tests/core/storage.test.js tests/core/workflow_state.test.js tests/core/graph_transform.test.js tests/core/legacy_text_helpers.test.js tests/core/legacy_widget_text_fallback.test.js tests/core/safe_media_draw.test.js tests/export/limits.test.js tests/export/fallback_media_helpers.test.js tests/export/offscreen_render_utils.test.js tests/ui/state.test.js tests/ui/preview_state.test.js tests/ui/elements.test.js tests/ui/export_filename.test.js tests/ui/webp_availability.test.js tests/smoke/module_imports.test.js"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workflow-image-export"
 description = "A simple ComfyUI extension to export images of your workflows with embedded JSON data."
-version = "1.1.0"
+version = "1.1.1"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)

--- a/tests/core/safe_media_draw.test.js
+++ b/tests/core/safe_media_draw.test.js
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  drawMediaSafely,
+  isCanvasOriginClean,
+} from "../../web/js/core/backends/safe_media_draw.mjs";
+
+class FakeContext {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.calls = [];
+  }
+
+  drawImage(source, ...args) {
+    this.calls.push(["drawImage", source, ...args]);
+    if (source?.throwOnDraw) {
+      throw new Error("draw failed");
+    }
+    if (source?.tainted) {
+      this.canvas.tainted = true;
+    }
+  }
+
+  getImageData() {
+    if (this.canvas.tainted) {
+      const error = new Error("tainted");
+      error.name = "SecurityError";
+      throw error;
+    }
+    return { data: new Uint8ClampedArray([0, 0, 0, 0]) };
+  }
+
+  fillRect(...args) {
+    this.calls.push(["fillRect", ...args]);
+  }
+
+  strokeRect(...args) {
+    this.calls.push(["strokeRect", ...args]);
+  }
+
+  fillText(...args) {
+    this.calls.push(["fillText", ...args]);
+  }
+
+  save() {}
+
+  restore() {}
+}
+
+class FakeCanvas {
+  constructor() {
+    this.width = 0;
+    this.height = 0;
+    this.tainted = false;
+    this.ctx = new FakeContext(this);
+  }
+
+  getContext() {
+    return this.ctx;
+  }
+}
+
+function withFakeDocument(fn) {
+  const originalDocument = globalThis.document;
+  globalThis.document = {
+    createElement(tagName) {
+      assert.equal(tagName, "canvas");
+      return new FakeCanvas();
+    },
+  };
+  try {
+    return fn();
+  } finally {
+    globalThis.document = originalDocument;
+  }
+}
+
+test("isCanvasOriginClean returns false for tainted canvases", () => {
+  const canvas = new FakeCanvas();
+  assert.equal(isCanvasOriginClean(canvas), true);
+  canvas.tainted = true;
+  assert.equal(isCanvasOriginClean(canvas), false);
+});
+
+test("drawMediaSafely draws clean media through a scratch canvas", () => {
+  withFakeDocument(() => {
+    const exportCanvas = new FakeCanvas();
+    const media = { tainted: false };
+    const result = drawMediaSafely(exportCanvas.ctx, media, 10, 20, 30, 40);
+
+    assert.deepEqual(result, { ok: true, reason: "drawn" });
+    assert.equal(exportCanvas.tainted, false);
+    assert.equal(exportCanvas.ctx.calls.filter((call) => call[0] === "drawImage").length, 1);
+    assert.equal(exportCanvas.ctx.calls.some((call) => call[0] === "fillRect"), false);
+  });
+});
+
+test("drawMediaSafely placeholders tainted media without tainting export canvas", () => {
+  withFakeDocument(() => {
+    const exportCanvas = new FakeCanvas();
+    const media = { tainted: true };
+    const result = drawMediaSafely(exportCanvas.ctx, media, 10, 20, 80, 40);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "tainted");
+    assert.equal(exportCanvas.tainted, false);
+    assert.equal(exportCanvas.ctx.calls.some((call) => call[0] === "drawImage"), false);
+    assert.equal(exportCanvas.ctx.calls.some((call) => call[0] === "fillRect"), true);
+  });
+});

--- a/web/js/core/backends/legacy_dom_text_overlays.mjs
+++ b/web/js/core/backends/legacy_dom_text_overlays.mjs
@@ -10,6 +10,7 @@ import {
   normalizeSelectedNodeIds,
   shouldRenderResolvedNode,
 } from "./legacy_overlay_utils.mjs";
+import { drawMediaSafely } from "./safe_media_draw.mjs";
 import {
   captureElementAsCanvas,
   drawTextBlockToRect,
@@ -166,9 +167,11 @@ export async function drawDomWidgetOverlays({
       const captureBlank = captured?.canvas ? isCanvasBlank(captured.canvas) : false;
 
       if (captured?.canvas && !captureBlank) {
-        exportCtx.drawImage(captured.canvas, rx, ry, rw, rh);
-        drawn = true;
-        reason = "rendered-capture-drawn";
+        const result = drawMediaSafely(exportCtx, captured.canvas, rx, ry, rw, rh, {
+          placeholderLabel: "widget blocked",
+        });
+        drawn = result.ok;
+        reason = result.ok ? "rendered-capture-drawn" : `rendered-capture-${result.reason}`;
       } else {
         // Browser-only, dependency-free markdown export is content-first.
         // If foreignObject capture fails, prefer stable rendered text with an
@@ -229,26 +232,28 @@ export async function drawDomWidgetOverlays({
       const my = (directMedia.rect.y - bounds.top) * scale;
       const mw = directMedia.rect.w * scale;
       const mh = directMedia.rect.h * scale;
-      exportCtx.drawImage(directMedia.element, mx, my, mw, mh);
+      const result = drawMediaSafely(exportCtx, directMedia.element, mx, my, mw, mh);
       debugLog?.("diag.draw.widget", diagnoseDomElement(directMedia.element, uiCanvas, {
         stage: "draw",
-        reason: "direct-media-drawn",
+        reason: result.ok ? "direct-media-drawn" : `direct-media-${result.reason}`,
         exportRect: { x: mx, y: my, w: mw, h: mh },
         resolvedNodeId: nodeId,
         kind: "widget-media",
       }));
-      if (Number.isFinite(nodeId)) coveredNodeIds.add(nodeId);
+      if (result.ok && Number.isFinite(nodeId)) coveredNodeIds.add(nodeId);
     } else if (captured?.canvas) {
-      exportCtx.drawImage(captured.canvas, x, y, w, h);
+      const result = drawMediaSafely(exportCtx, captured.canvas, x, y, w, h, {
+        placeholderLabel: "widget blocked",
+      });
       debugLog?.("diag.draw.widget", diagnoseDomElement(widget, uiCanvas, {
         stage: "draw",
-        reason: "capture-drawn",
+        reason: result.ok ? "capture-drawn" : `capture-${result.reason}`,
         captureStage: captured.stage,
         exportRect: { x, y, w, h },
         resolvedNodeId: nodeId,
         kind: "widget",
       }));
-      if (Number.isFinite(nodeId)) coveredNodeIds.add(nodeId);
+      if (result.ok && Number.isFinite(nodeId)) coveredNodeIds.add(nodeId);
     } else {
       debugLog?.("diag.draw.widget", diagnoseDomElement(widget, uiCanvas, {
         stage: "draw",

--- a/web/js/core/backends/legacy_media_overlays.mjs
+++ b/web/js/core/backends/legacy_media_overlays.mjs
@@ -14,6 +14,7 @@ import {
   normalizeSelectedNodeIds,
   shouldRenderResolvedNode,
 } from "./legacy_overlay_utils.mjs";
+import { drawMediaSafely } from "./safe_media_draw.mjs";
 
 function findGraphNodeById(graph, id) {
   if (!Number.isFinite(id)) return null;
@@ -89,12 +90,14 @@ function drawVideoIntoGraphRect({ exportCtx, video, graphRect, bounds, scale }) 
     const fit = Math.min(w / sourceW, h / sourceH);
     const fitW = sourceW * fit;
     const fitH = sourceH * fit;
-    exportCtx.drawImage(video, x + (w - fitW) / 2, y + (h - fitH) / 2, fitW, fitH);
-    return { x: x + (w - fitW) / 2, y: y + (h - fitH) / 2, w: fitW, h: fitH };
+    const fitX = x + (w - fitW) / 2;
+    const fitY = y + (h - fitH) / 2;
+    const result = drawMediaSafely(exportCtx, video, fitX, fitY, fitW, fitH);
+    return { x: fitX, y: fitY, w: fitW, h: fitH, safeDraw: result };
   }
 
-  exportCtx.drawImage(video, x, y, w, h);
-  return { x, y, w, h };
+  const result = drawMediaSafely(exportCtx, video, x, y, w, h);
+  return { x, y, w, h, safeDraw: result };
 }
 
 export function drawVideoOverlays({
@@ -154,7 +157,7 @@ export function drawVideoOverlays({
         const exportRect = drawVideoIntoGraphRect({ exportCtx, video, graphRect: previewRect, bounds, scale });
         debugLog?.("diag.draw.video", diagnoseDomElement(video, uiCanvas, {
           stage: "draw",
-          reason,
+          reason: exportRect.safeDraw?.ok ? reason : `${reason}:${exportRect.safeDraw?.reason || "media-blocked"}`,
           readyState: video.readyState,
           graphRect: previewRect,
           exportRect,
@@ -165,7 +168,9 @@ export function drawVideoOverlays({
           },
           kind: "video",
         }));
-        drawnNodeIds.add(resolved.nodeRect.id);
+        if (exportRect.safeDraw?.ok) {
+          drawnNodeIds.add(resolved.nodeRect.id);
+        }
         return true;
       } catch (error) {
         debugLog?.("diag.draw.video", diagnoseDomElement(video, uiCanvas, {
@@ -223,11 +228,13 @@ export function drawVideoOverlays({
     const h = graphH * scale;
 
     try {
-      exportCtx.drawImage(video, x, y, w, h);
-      drawnNodeIds.add(matchedNode.id);
+      const result = drawMediaSafely(exportCtx, video, x, y, w, h);
+      if (result.ok) {
+        drawnNodeIds.add(matchedNode.id);
+      }
       debugLog?.("diag.draw.video", diagnoseDomElement(video, uiCanvas, {
         stage: "draw",
-        reason: "drawn",
+        reason: result.ok ? "drawn" : result.reason,
         readyState: video.readyState,
         graphRect: { x: graphX, y: graphY, w: graphW, h: graphH },
         exportRect: { x, y, w, h },
@@ -320,10 +327,10 @@ export function drawVhsVideoOverlays({
     const h = graphH * scale;
 
     try {
-      exportCtx.drawImage(video, x, y, w, h);
+      const result = drawMediaSafely(exportCtx, video, x, y, w, h);
       debugLog?.("diag.draw.vhs", diagnoseDomElement(video, uiCanvas, {
         stage: "draw",
-        reason: "drawn",
+        reason: result.ok ? "drawn" : result.reason,
         readyState: video.readyState,
         graphRect: { x: graphX, y: graphY, w: graphW, h: graphH },
         exportRect: { x, y, w, h },
@@ -375,8 +382,8 @@ export function drawImageOverlays({
     const h = rect.h * scale;
 
     try {
-      exportCtx.drawImage(el, x, y, w, h);
-      debugLog?.("dom.image.item", { x, y, w, h });
+      const result = drawMediaSafely(exportCtx, el, x, y, w, h);
+      debugLog?.("dom.image.item", { x, y, w, h, safeDraw: result.reason });
     } catch (error) {
       debugLog?.("dom.image.error", { message: error?.message || String(error) });
     }

--- a/web/js/core/backends/safe_media_draw.mjs
+++ b/web/js/core/backends/safe_media_draw.mjs
@@ -1,0 +1,95 @@
+function toPositiveSize(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return 0;
+  return Math.max(1, Math.ceil(number));
+}
+
+function getCanvasContext(canvas) {
+  try {
+    return canvas?.getContext?.("2d", { alpha: true }) || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+export function isCanvasOriginClean(canvas) {
+  const ctx = getCanvasContext(canvas);
+  if (!ctx) return false;
+  try {
+    ctx.getImageData(0, 0, 1, 1);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function drawBlockedMediaPlaceholder(ctx, x, y, w, h, label = "media blocked") {
+  if (!ctx || w <= 0 || h <= 0) return;
+  ctx.save?.();
+  ctx.fillStyle = "rgba(20, 20, 20, 0.92)";
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.18)";
+  ctx.lineWidth = 1;
+  ctx.strokeRect?.(x + 0.5, y + 0.5, Math.max(0, w - 1), Math.max(0, h - 1));
+  if (w >= 44 && h >= 18 && typeof ctx.fillText === "function") {
+    ctx.fillStyle = "rgba(255, 255, 255, 0.72)";
+    ctx.font = `${Math.max(9, Math.min(12, Math.floor(h / 6)))}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(label, x + w / 2, y + h / 2, Math.max(10, w - 8));
+  }
+  ctx.restore?.();
+}
+
+export function drawMediaSafely(exportCtx, media, x, y, w, h, options = {}) {
+  const width = toPositiveSize(w);
+  const height = toPositiveSize(h);
+  if (!exportCtx || !media || !width || !height) {
+    return { ok: false, reason: "invalid-geometry" };
+  }
+
+  const scratch = document.createElement("canvas");
+  scratch.width = width;
+  scratch.height = height;
+  const scratchCtx = getCanvasContext(scratch);
+  if (!scratchCtx) {
+    if (options.drawPlaceholder !== false) {
+      drawBlockedMediaPlaceholder(exportCtx, x, y, w, h, options.placeholderLabel);
+    }
+    return { ok: false, reason: "scratch-context-unavailable" };
+  }
+
+  try {
+    scratchCtx.drawImage(media, 0, 0, width, height);
+  } catch (error) {
+    if (options.drawPlaceholder !== false) {
+      drawBlockedMediaPlaceholder(exportCtx, x, y, w, h, options.placeholderLabel);
+    }
+    return {
+      ok: false,
+      reason: "drawImage-error",
+      error,
+    };
+  }
+
+  if (!isCanvasOriginClean(scratch)) {
+    if (options.drawPlaceholder !== false) {
+      drawBlockedMediaPlaceholder(exportCtx, x, y, w, h, options.placeholderLabel);
+    }
+    return { ok: false, reason: "tainted" };
+  }
+
+  try {
+    exportCtx.drawImage(scratch, x, y, w, h);
+    return { ok: true, reason: "drawn" };
+  } catch (error) {
+    if (options.drawPlaceholder !== false) {
+      drawBlockedMediaPlaceholder(exportCtx, x, y, w, h, options.placeholderLabel);
+    }
+    return {
+      ok: false,
+      reason: "export-drawImage-error",
+      error,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a scratch-canvas guard for legacy DOM media drawing
- render a small placeholder instead of tainting the final export canvas when DOM media is blocked
- keep video thumbnail fallback available when direct DOM video drawing fails
- add focused tests for clean and tainted media drawing

## Tests
- npm test