### PR TITLE
Add legacy link visibility export toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install via **ComfyUI Manager**:
 
 > [!NOTE]
 > Node 2.0 mode disables or simplifies options that cannot be reproduced by browser compositor capture.
-> Transparent background, padding, selection scope, and node opacity are not available in Node 2.0 mode.
+> Transparent background, padding, link visibility, selection scope, and node opacity are not available in Node 2.0 mode.
 
 - **Format**: PNG / WebP  
   - Workflow embedding is **PNG only**.
@@ -43,6 +43,7 @@ Install via **ComfyUI Manager**:
   - Classic: UI / Transparent / Solid.
   - Node 2.0: UI / Solid.
 - **Padding**: margin around the captured bounds (slider).
+- **Show links**: include node links in Classic/LiteGraph exports.
 - **Scope** (when nodes are selected):
   - **Scope** toggle: crop to selection.
   - **Opacity**: dim unselected nodes (0–100).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test tests/core/settings_state.test.js tests/core/storage.test.js tests/core/workflow_state.test.js tests/core/graph_transform.test.js tests/core/legacy_text_helpers.test.js tests/core/legacy_widget_text_fallback.test.js tests/core/safe_media_draw.test.js tests/export/limits.test.js tests/export/fallback_media_helpers.test.js tests/export/offscreen_render_utils.test.js tests/ui/state.test.js tests/ui/preview_state.test.js tests/ui/elements.test.js tests/ui/export_filename.test.js tests/ui/webp_availability.test.js tests/smoke/module_imports.test.js"
+    "test": "node --test tests/core/settings_state.test.js tests/core/storage.test.js tests/core/workflow_state.test.js tests/core/graph_transform.test.js tests/core/legacy_text_helpers.test.js tests/core/legacy_widget_text_fallback.test.js tests/core/safe_media_draw.test.js tests/export/limits.test.js tests/export/link_visibility.test.js tests/export/fallback_media_helpers.test.js tests/export/offscreen_render_utils.test.js tests/ui/state.test.js tests/ui/preview_state.test.js tests/ui/elements.test.js tests/ui/export_filename.test.js tests/ui/webp_availability.test.js tests/smoke/module_imports.test.js"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workflow-image-export"
 description = "A simple ComfyUI extension to export images of your workflows with embedded JSON data."
-version = "1.1.2"
+version = "1.1.3"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)

--- a/tests/core/settings_state.test.js
+++ b/tests/core/settings_state.test.js
@@ -30,6 +30,16 @@ test("normalizeState handles legacy string embed workflow values", () => {
   assert.equal(normalizeState({ embedWorkflow: "0" }).embedWorkflow, false);
 });
 
+test("normalizeState keeps show links enabled by default and coerces stored values", () => {
+  assert.equal(normalizeState({}).showLinks, true);
+  assert.equal(normalizeState({ showLinks: false }).showLinks, false);
+  assert.equal(normalizeState({ showLinks: "false" }).showLinks, false);
+  assert.equal(normalizeState({ showLinks: "0" }).showLinks, false);
+  assert.equal(normalizeState({ showLinks: "true" }).showLinks, true);
+  assert.equal(normalizeState({ showLinks: "1" }).showLinks, true);
+  assert.equal(normalizeState({ showLinks: "maybe" }).showLinks, DEFAULTS.showLinks);
+});
+
 test("normalizeState falls back to the default for unknown embed workflow strings", () => {
   const state = normalizeState({ embedWorkflow: "maybe" });
   assert.equal(state.embedWorkflow, DEFAULTS.embedWorkflow);

--- a/tests/export/link_visibility.test.js
+++ b/tests/export/link_visibility.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { hideGraphLinks } from "../../web/js/export/link_visibility.mjs";
+
+test("hideGraphLinks detaches graph and node link references until restored", () => {
+  const links = {
+    10: { origin_id: 1, target_id: 2 },
+    11: { origin_id: 1, target_id: 2 },
+  };
+  const graph = {
+    _nodes: [
+      {
+        id: 1,
+        inputs: [{ link: 9 }],
+        outputs: [{ links: [10, 11] }],
+      },
+      {
+        id: 2,
+        inputs: [{ link: 10 }],
+        outputs: [],
+      },
+    ],
+    links,
+  };
+
+  const restore = hideGraphLinks(graph);
+
+  assert.deepEqual(graph.links, {});
+  assert.equal(graph._nodes[0].inputs[0].link, null);
+  assert.deepEqual(graph._nodes[0].outputs[0].links, []);
+  assert.equal(graph._nodes[1].inputs[0].link, null);
+
+  restore();
+
+  assert.equal(graph.links, links);
+  assert.equal(graph._nodes[0].inputs[0].link, 9);
+  assert.deepEqual(graph._nodes[0].outputs[0].links, [10, 11]);
+  assert.equal(graph._nodes[1].inputs[0].link, 10);
+});

--- a/tests/export/offscreen_render_utils.test.js
+++ b/tests/export/offscreen_render_utils.test.js
@@ -67,8 +67,53 @@ test("applyLinkFilter clears object links for none mode without selected ids", (
   assert.deepEqual(graph.links, {});
 });
 
+test("applyLinkFilter clears node-side link references for none mode", () => {
+  const graph = {
+    _nodes: [
+      {
+        id: 1,
+        inputs: [{ link: 10 }],
+        outputs: [{ links: [10, 11] }],
+      },
+      {
+        id: 2,
+        inputs: [{ link: 11 }],
+        outputs: [],
+      },
+    ],
+    links: {
+      10: { origin_id: 1, target_id: 2 },
+      11: { origin_id: 1, target_id: 2 },
+    },
+  };
+
+  applyLinkFilter(graph, [], "none");
+
+  assert.deepEqual(graph.links, {});
+  assert.equal(graph._nodes[0].inputs[0].link, null);
+  assert.deepEqual(graph._nodes[0].outputs[0].links, []);
+  assert.equal(graph._nodes[1].inputs[0].link, null);
+});
+
 test("applyLinkFilter preserves selected link filtering behavior", () => {
   const graph = {
+    _nodes: [
+      {
+        id: 1,
+        inputs: [],
+        outputs: [{ links: [1, 2] }],
+      },
+      {
+        id: 2,
+        inputs: [{ link: 1 }],
+        outputs: [{ links: [2] }],
+      },
+      {
+        id: 3,
+        inputs: [{ link: 2 }],
+        outputs: [],
+      },
+    ],
     links: {
       1: { origin_id: 1, target_id: 2 },
       2: { origin_id: 2, target_id: 3 },
@@ -80,4 +125,8 @@ test("applyLinkFilter preserves selected link filtering behavior", () => {
   assert.deepEqual(graph.links, {
     1: { origin_id: 1, target_id: 2 },
   });
+  assert.deepEqual(graph._nodes[0].outputs[0].links, [1]);
+  assert.equal(graph._nodes[1].inputs[0].link, 1);
+  assert.deepEqual(graph._nodes[1].outputs[0].links, []);
+  assert.equal(graph._nodes[2].inputs[0].link, null);
 });

--- a/tests/ui/preview_state.test.js
+++ b/tests/ui/preview_state.test.js
@@ -43,6 +43,7 @@ test("getPreviewStateKey includes visual inputs and workflow signature only", ()
     background: "solid",
     solidColor: "#123456",
     padding: 100,
+    showLinks: true,
     nodeOpacity: 100,
     scopeSelected: false,
     scopeOpacity: 40,
@@ -54,9 +55,11 @@ test("getPreviewStateKey includes visual inputs and workflow signature only", ()
   const key = getPreviewStateKey(base);
   const sameKey = getPreviewStateKey({ ...base, workflowJsonText: "changed" });
   const changedKey = getPreviewStateKey({ ...base, padding: 120 });
+  const changedLinksKey = getPreviewStateKey({ ...base, showLinks: false });
 
   assert.equal(key, sameKey);
   assert.notEqual(key, changedKey);
+  assert.notEqual(key, changedLinksKey);
 });
 
 test("getPreviewMime resolves raster preview mime", () => {

--- a/tests/ui/state.test.js
+++ b/tests/ui/state.test.js
@@ -78,6 +78,7 @@ test("toLastUsedState serializes only normalized export and scope values", () =>
     solidColor: "#1f1f1f",
     nodeOpacity: 100,
     padding: 100,
+    showLinks: true,
     outputResolution: "auto",
     maxLongEdge: 4096,
     exceedMode: "tile",

--- a/web/js/core/backends/legacy_capture.mjs
+++ b/web/js/core/backends/legacy_capture.mjs
@@ -236,6 +236,7 @@ export async function captureLegacy(options = {}) {
         exportCtx,
         bgctx: offscreen.bgctx,
         solidColor: options?.solidColor,
+        showLinks: options?.showLinks !== false,
         resetTransform: () => configureTransform(offscreen, bounds, width, height, scale, debugLog),
       })
     );

--- a/web/js/core/backends/legacy_support.mjs
+++ b/web/js/core/backends/legacy_support.mjs
@@ -1,4 +1,5 @@
 import { resolveUiBackgroundColor } from "../../export/background_modes.mjs";
+import { hideGraphLinks } from "../../export/link_visibility.mjs";
 import { createExportDragAndScale } from "../graph_transform.mjs";
 
 export function ensure2DContext(canvas) {
@@ -326,8 +327,23 @@ export function configureTransform(offscreen, bounds, viewportW, viewportH, scal
   }
 }
 
+function drawWithOptionalLinks(offscreen, showLinks) {
+  const graph = offscreen?.graph || offscreen?._graph;
+  if (showLinks !== false || !graph) {
+    offscreen.draw(true, true);
+    return;
+  }
+
+  const restoreLinks = hideGraphLinks(graph);
+  try {
+    offscreen.draw(true, true);
+  } finally {
+    restoreLinks();
+  }
+}
+
 export async function drawOffscreen(offscreen, options = {}) {
-  offscreen.draw(true, true);
+  drawWithOptionalLinks(offscreen, options.showLinks);
   await new Promise((resolve) => requestAnimationFrame(resolve));
 
   if (typeof options.resetTransform === "function") {
@@ -343,5 +359,5 @@ export async function drawOffscreen(offscreen, options = {}) {
     options.solidColor
   );
 
-  offscreen.draw(true, true);
+  drawWithOptionalLinks(offscreen, options.showLinks);
 }

--- a/web/js/core/capture/index.mjs
+++ b/web/js/core/capture/index.mjs
@@ -92,6 +92,8 @@ export async function capture(options = {}) {
         scopeSelected: Boolean(normalized.scopeSelected),
         scopeOpacity: normalized.scopeOpacity,
         selectedNodeIds,
+        showLinks: normalized.showLinks !== false,
+        linkFilter: normalized.showLinks === false ? "none" : "all",
         onProgress: normalized.onProgress,
         exceedMode: normalized.exceedMode,
         tileBleed: normalized.tileBleed,
@@ -115,6 +117,7 @@ export async function capture(options = {}) {
         scopeSelected: Boolean(normalized.scopeSelected),
         scopeOpacity: normalized.scopeOpacity,
         selectedNodeIds,
+        showLinks: normalized.showLinks !== false,
         skipWidgetCapture: true,
       });
     }

--- a/web/js/core/settings.mjs
+++ b/web/js/core/settings.mjs
@@ -11,6 +11,7 @@ export const SETTING_IDS = {
   solidColor: "WorkflowImageExport.SolidColor",
   nodeOpacity: "WorkflowImageExport.NodeOpacity",
   padding: "WorkflowImageExport.Padding",
+  showLinks: "WorkflowImageExport.ShowLinks",
   outputResolution: "WorkflowImageExport.OutputResolution",
   maxLongEdge: "WorkflowImageExport.MaxLongEdge",
   exceedMode: "WorkflowImageExport.ExceedMode",
@@ -101,6 +102,14 @@ const SETTINGS_DEFINITIONS = [
     tooltip: "Extra padding around the captured bounds.",
   },
   {
+    id: SETTING_IDS.showLinks,
+    name: "Show links",
+    category: cat(BASIC, "Show links"),
+    type: "boolean",
+    defaultValue: DEFAULTS.showLinks,
+    tooltip: "Include node links in exported images.",
+  },
+  {
     id: SETTING_IDS.solidColor,
     name: "Solid color",
     category: cat(BASIC, "Solid color"),
@@ -189,6 +198,7 @@ export function getDefaultsFromSettings() {
     solidColor: get(SETTING_IDS.solidColor, DEFAULTS.solidColor),
     nodeOpacity: get(SETTING_IDS.nodeOpacity, DEFAULTS.nodeOpacity),
     padding: get(SETTING_IDS.padding, DEFAULTS.padding),
+    showLinks: get(SETTING_IDS.showLinks, DEFAULTS.showLinks),
     outputResolution: get(SETTING_IDS.outputResolution, DEFAULTS.outputResolution),
     maxLongEdge: get(SETTING_IDS.maxLongEdge, DEFAULTS.maxLongEdge),
     exceedMode: get(SETTING_IDS.exceedMode, DEFAULTS.exceedMode),
@@ -207,6 +217,7 @@ function toSettingFormat(state) {
     solidColor: state.solidColor,
     nodeOpacity: state.nodeOpacity,
     padding: state.padding,
+    showLinks: state.showLinks,
     outputResolution: state.outputResolution,
     maxLongEdge: state.maxLongEdge,
     exceedMode: state.exceedMode,
@@ -226,6 +237,7 @@ export function setDefaultsInSettings(state) {
   access.set(SETTING_IDS.solidColor, values.solidColor);
   access.set(SETTING_IDS.nodeOpacity, values.nodeOpacity);
   access.set(SETTING_IDS.padding, values.padding);
+  access.set(SETTING_IDS.showLinks, values.showLinks);
   access.set(SETTING_IDS.outputResolution, values.outputResolution);
   access.set(SETTING_IDS.maxLongEdge, values.maxLongEdge);
   access.set(SETTING_IDS.exceedMode, values.exceedMode);

--- a/web/js/core/settings_state.mjs
+++ b/web/js/core/settings_state.mjs
@@ -5,6 +5,7 @@ export const DEFAULTS = {
   solidColor: "#1f1f1f",
   nodeOpacity: 100,
   padding: 100,
+  showLinks: true,
   outputResolution: "auto",
   maxLongEdge: 4096,
   exceedMode: "tile",
@@ -44,12 +45,16 @@ function normalizeExceedMode(value) {
 }
 
 function normalizeEmbedWorkflow(raw) {
-  const hasEmbedWorkflow = Object.prototype.hasOwnProperty.call(raw ?? {}, "embedWorkflow");
-  if (!hasEmbedWorkflow) {
-    return DEFAULTS.embedWorkflow;
+  return normalizeBoolean(raw, "embedWorkflow", DEFAULTS.embedWorkflow);
+}
+
+function normalizeBoolean(raw, key, fallback) {
+  const hasValue = Object.prototype.hasOwnProperty.call(raw ?? {}, key);
+  if (!hasValue) {
+    return fallback;
   }
 
-  const value = raw.embedWorkflow;
+  const value = raw[key];
   if (typeof value === "boolean") {
     return value;
   }
@@ -61,7 +66,7 @@ function normalizeEmbedWorkflow(raw) {
   if (normalized === "false" || normalized === "0") {
     return false;
   }
-  return DEFAULTS.embedWorkflow;
+  return fallback;
 }
 
 function normalizeNumber(value, fallback) {
@@ -86,6 +91,7 @@ export function normalizeState(raw) {
     solidColor: typeof raw?.solidColor === "string" ? raw.solidColor : DEFAULTS.solidColor,
     nodeOpacity: normalizeNumber(raw?.nodeOpacity, DEFAULTS.nodeOpacity),
     padding: normalizeNumber(raw?.padding, DEFAULTS.padding),
+    showLinks: normalizeBoolean(raw, "showLinks", DEFAULTS.showLinks),
     outputResolution: normalizeResolution(raw?.outputResolution),
     maxLongEdge: normalizeNumber(raw?.maxLongEdge, DEFAULTS.maxLongEdge),
     exceedMode: normalizeExceedMode(raw?.exceedMode),

--- a/web/js/export/index.mjs
+++ b/web/js/export/index.mjs
@@ -194,6 +194,8 @@ export async function exportWorkflowPng(workflowJson, options = {}) {
     maxPixels: 0,
     scale,
     nodeOpacity,
+    showLinks: options.showLinks !== false,
+    linkFilter: options.linkFilter,
   };
 
   let bboxOverride = null;

--- a/web/js/export/link_visibility.mjs
+++ b/web/js/export/link_visibility.mjs
@@ -1,0 +1,127 @@
+function createEmptyLinksLike(links) {
+  if (links instanceof Map) return new Map();
+  if (links instanceof Set) return new Set();
+  if (Array.isArray(links)) return [];
+  if (links && typeof links === "object") return {};
+  return links;
+}
+
+function createEmptyLinkListLike(links) {
+  if (links instanceof Set) return new Set();
+  return [];
+}
+
+function getGraphNodes(graph) {
+  const seen = new Set();
+  const nodes = [];
+  const add = (node) => {
+    if (!node || seen.has(node)) return;
+    seen.add(node);
+    nodes.push(node);
+  };
+
+  if (Array.isArray(graph?._nodes)) {
+    graph._nodes.forEach(add);
+  }
+  if (Array.isArray(graph?.nodes)) {
+    graph.nodes.forEach(add);
+  } else if (graph?.nodes instanceof Map) {
+    graph.nodes.forEach(add);
+  } else if (graph?.nodes && typeof graph.nodes === "object") {
+    Object.values(graph.nodes).forEach(add);
+  }
+
+  return nodes;
+}
+
+function getLinkIdSet(links) {
+  if (links instanceof Map) {
+    return new Set([...links.keys()].map((id) => Number(id)).filter(Number.isFinite));
+  }
+  if (Array.isArray(links)) {
+    return new Set(
+      links
+        .map((link, index) => Number(link?.id ?? link?.[0] ?? index))
+        .filter(Number.isFinite)
+    );
+  }
+  if (links && typeof links === "object") {
+    return new Set(Object.keys(links).map((id) => Number(id)).filter(Number.isFinite));
+  }
+  return new Set();
+}
+
+function linkListToArray(value) {
+  if (value instanceof Set) return [...value];
+  if (Array.isArray(value)) return value;
+  return [];
+}
+
+export function detachNodeLinkRefs(graph, keepIds = null) {
+  const restoreEntries = [];
+  const shouldKeep = (id) => {
+    if (!keepIds) return false;
+    const num = Number(id);
+    return Number.isFinite(num) && keepIds.has(num);
+  };
+
+  for (const node of getGraphNodes(graph)) {
+    if (Array.isArray(node.inputs)) {
+      for (const input of node.inputs) {
+        if (!input || typeof input !== "object" || !("link" in input)) continue;
+        const prev = input.link;
+        if (shouldKeep(prev)) continue;
+        restoreEntries.push({ target: input, key: "link", value: prev });
+        input.link = null;
+      }
+    }
+
+    if (Array.isArray(node.outputs)) {
+      for (const output of node.outputs) {
+        if (!output || typeof output !== "object") continue;
+        if ("links" in output) {
+          const prev = output.links;
+          const kept = linkListToArray(prev).filter(shouldKeep);
+          if (kept.length === linkListToArray(prev).length) continue;
+          restoreEntries.push({ target: output, key: "links", value: prev });
+          output.links = keepIds ? kept : createEmptyLinkListLike(prev);
+        }
+        if ("link" in output) {
+          const prev = output.link;
+          if (shouldKeep(prev)) continue;
+          restoreEntries.push({ target: output, key: "link", value: prev });
+          output.link = null;
+        }
+      }
+    }
+  }
+
+  return () => {
+    for (let i = restoreEntries.length - 1; i >= 0; i -= 1) {
+      const entry = restoreEntries[i];
+      entry.target[entry.key] = entry.value;
+    }
+  };
+}
+
+export function hideGraphLinks(graph) {
+  const restoreFns = [];
+  if (graph && "links" in graph) {
+    const originalLinks = graph.links;
+    graph.links = createEmptyLinksLike(originalLinks);
+    restoreFns.push(() => {
+      graph.links = originalLinks;
+    });
+  }
+  restoreFns.push(detachNodeLinkRefs(graph));
+
+  return () => {
+    for (let i = restoreFns.length - 1; i >= 0; i -= 1) {
+      restoreFns[i]();
+    }
+  };
+}
+
+export function syncNodeLinkRefsToGraphLinks(graph) {
+  return detachNodeLinkRefs(graph, getLinkIdSet(graph?.links));
+}

--- a/web/js/export/offscreen_render_utils.mjs
+++ b/web/js/export/offscreen_render_utils.mjs
@@ -1,3 +1,5 @@
+import { hideGraphLinks, syncNodeLinkRefsToGraphLinks } from "./link_visibility.mjs";
+
 export function applyRenderFilter(graph, selectedNodeIds, mode) {
   if (!graph || !mode || mode === "all") return;
   const nodes = graph?._nodes || graph?.nodes || [];
@@ -39,11 +41,7 @@ export function applyRenderFilter(graph, selectedNodeIds, mode) {
 export function applyLinkFilter(graph, selectedNodeIds, mode) {
   if (!graph || !mode || mode === "all") return;
   if (mode === "none") {
-    if (graph.links instanceof Map) {
-      graph.links = new Map();
-    } else if (graph.links && typeof graph.links === "object") {
-      graph.links = {};
-    }
+    hideGraphLinks(graph);
     return;
   }
   const ids = Array.isArray(selectedNodeIds)
@@ -76,6 +74,7 @@ export function applyLinkFilter(graph, selectedNodeIds, mode) {
       }
     }
     graph.links = next;
+    syncNodeLinkRefsToGraphLinks(graph);
     return;
   }
 
@@ -87,6 +86,7 @@ export function applyLinkFilter(graph, selectedNodeIds, mode) {
       }
     }
     graph.links = next;
+    syncNodeLinkRefsToGraphLinks(graph);
   }
 }
 

--- a/web/js/export/render_graph_offscreen.mjs
+++ b/web/js/export/render_graph_offscreen.mjs
@@ -145,7 +145,11 @@ export async function renderGraphOffscreen(workflowJson, options = {}) {
     }));
   perfLog?.("bbox.ready", { width: bbox.width, height: bbox.height });
   applyRenderFilter(graph, options.selectedNodeIds, options.renderFilter);
-  applyLinkFilter(graph, options.selectedNodeIds, options.linkFilter);
+  applyLinkFilter(
+    graph,
+    options.selectedNodeIds,
+    options.showLinks === false ? "none" : options.linkFilter
+  );
   const baseWidth = Math.max(1, Math.ceil(bbox.width));
   const baseHeight = Math.max(1, Math.ceil(bbox.height));
   const tileRect = options.tileRect || null;

--- a/web/js/ui/dialog.mjs
+++ b/web/js/ui/dialog.mjs
@@ -265,6 +265,8 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   paddingWrapper.appendChild(paddingInput);
   paddingWrapper.appendChild(paddingValue);
 
+  const showLinksToggle = createToggle();
+
   const nodeOpacityInput = document.createElement("input");
   nodeOpacityInput.type = "range";
   nodeOpacityInput.min = "0";
@@ -473,6 +475,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     solidColorInput.value = nextState.solidColor;
     paddingInput.value = String(nextState.padding);
     paddingValue.textContent = String(nextState.padding);
+    showLinksToggle.input.checked = nextState.showLinks !== false;
     const nodeOpacity = Number.isFinite(Number(nextState.nodeOpacity)) ? nextState.nodeOpacity : 100;
     nodeOpacityInput.value = String(nodeOpacity);
     nodeOpacityValue.textContent = String(nodeOpacity);
@@ -493,6 +496,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     }
     if (isNode2Backend) {
       paddingInput.disabled = true;
+      showLinksToggle.input.disabled = true;
       nodeOpacityInput.disabled = true;
       pngCompressionInput.disabled = true;
       maxLongEdgeInput.disabled = true;
@@ -510,6 +514,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
       background: [...backgroundGroup.inputs.values()].find((input) => input.checked)?.value,
       solidColor: solidColorInput.value,
       padding: paddingInput.value,
+      showLinks: showLinksToggle.input.checked,
       nodeOpacity: nodeOpacityInput.value,
       pngCompression: pngCompressionInput.value,
       maxLongEdge: maxLongEdgeInput.value,
@@ -551,6 +556,8 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
 
   let previewUrl = null;
   let previewSnapshot = null;
+  const previewCache = new Map();
+  const PREVIEW_CACHE_LIMIT = 4;
   let previewTimer = null;
   let previewIdle = null;
   let previewBusy = false;
@@ -594,6 +601,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     previewQueued = false;
     previewBusy = false;
     previewSnapshot = null;
+    previewCache.clear();
     if (previewUrl) {
       try {
         URL.revokeObjectURL(previewUrl);
@@ -638,6 +646,37 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     return encoded;
   }
 
+  function cachePreviewSnapshot(snapshot) {
+    if (!snapshot?.key) return;
+    if (previewCache.has(snapshot.key)) {
+      previewCache.delete(snapshot.key);
+    }
+    previewCache.set(snapshot.key, snapshot);
+    while (previewCache.size > PREVIEW_CACHE_LIMIT) {
+      const oldestKey = previewCache.keys().next().value;
+      previewCache.delete(oldestKey);
+    }
+  }
+
+  async function displayPreviewSnapshot(snapshot, previewState) {
+    if (!snapshot) return false;
+    if (snapshot.canvas && drawPreviewCanvas(snapshot.canvas)) {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        previewUrl = null;
+      }
+      return true;
+    }
+    const displayBlob = snapshot.blob || await encodePreviewSnapshot(snapshot, previewState);
+    if (!displayBlob) return false;
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    previewUrl = URL.createObjectURL(displayBlob);
+    previewImg.src = previewUrl;
+    return true;
+  }
+
   async function renderPreview(previewStateOverride = null, options = {}) {
     if (dialogClosed) return;
     if (isNode2Backend) {
@@ -659,6 +698,15 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     }
     const previewState = previewStateOverride || buildPreviewState();
     const previewKey = getPreviewStateKey(previewState);
+    const cachedSnapshot = previewCache.get(previewKey);
+    if (cachedSnapshot) {
+      previewCache.delete(previewKey);
+      previewCache.set(previewKey, cachedSnapshot);
+      previewSnapshot = cachedSnapshot;
+      await displayPreviewSnapshot(cachedSnapshot, previewState);
+      previewFrame.classList.remove("is-loading");
+      return cachedSnapshot;
+    }
     try {
       previewBusy = true;
       previewFrame.classList.add("is-loading");
@@ -685,19 +733,8 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
         mime: previewResult?.mime || getPreviewMime(previewState),
         state: previewState,
       };
-      if (canvas && drawPreviewCanvas(canvas)) {
-        if (previewUrl) {
-          URL.revokeObjectURL(previewUrl);
-          previewUrl = null;
-        }
-        return previewSnapshot;
-      }
-      const displayBlob = blob || await encodePreviewSnapshot(previewSnapshot, previewState);
-      if (previewUrl) {
-        URL.revokeObjectURL(previewUrl);
-      }
-      previewUrl = URL.createObjectURL(displayBlob);
-      previewImg.src = previewUrl;
+      cachePreviewSnapshot(previewSnapshot);
+      await displayPreviewSnapshot(previewSnapshot, previewState);
       return previewSnapshot;
     } catch (error) {
       log?.("preview:error", { message: error?.message || String(error) });
@@ -782,6 +819,7 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
     handleChange();
   });
   paddingInput.addEventListener("change", () => scheduleWebpCheck());
+  showLinksToggle.input.addEventListener("change", () => handleChange());
   pngCompressionInput.addEventListener("input", () => {
     pngCompressionValue.textContent = pngCompressionInput.value;
     handleChange();
@@ -1048,6 +1086,13 @@ export function openExportDialog({ onExportStarted, onExportFinished, log } = {}
   controlsScroll.appendChild(markNode2UnsupportedRow(
     paddingRow,
     "Padding is not applied in Node 2.0 compositor capture."
+  ));
+  const showLinksRow = createRow("Show links", showLinksToggle.wrapper, {
+    helpText: "Include node links in exports.",
+  });
+  controlsScroll.appendChild(markNode2UnsupportedRow(
+    showLinksRow,
+    "Link visibility is only available in the legacy renderer."
   ));
   const scopeRow = createRow("Scope", scopeToggle.wrapper);
   controlsScroll.appendChild(markNode2UnsupportedRow(

--- a/web/js/ui/preview_state.mjs
+++ b/web/js/ui/preview_state.mjs
@@ -27,6 +27,7 @@ export function getPreviewStateKey(previewState) {
     background: previewState.background,
     solidColor: previewState.solidColor,
     padding: previewState.padding,
+    showLinks: previewState.showLinks,
     nodeOpacity: previewState.nodeOpacity,
     scopeSelected: previewState.scopeSelected,
     scopeOpacity: previewState.scopeOpacity,


### PR DESCRIPTION
## Summary
- Add a Classic/LiteGraph `Show links` toggle below Padding in the export dialog
- Hide links in normal legacy capture and tiled/offscreen export paths, including node-side link references
- Cache recent preview states so toggling back can reuse the prior preview canvas

## Validation
- `npm test`
- `node --test tests/export/link_visibility.test.js tests/export/offscreen_render_utils.test.js tests/smoke/module_imports.test.js`

Fixes #29