### PR TITLE
Prepare release 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://github.com/user-attachments/assets/f705aae4-d082-4d68-a1be-57c0d3076327
 - Embed workflow JSON metadata (PNG only)
 - Selection-based cropping with opacity control
 - Node 2.0 compositor capture support for current Chromium-based browsers
+- Transparent Node 2.0 export with full-resolution tiled capture
 
 ## Installation
 
@@ -34,14 +35,13 @@ Install via **ComfyUI Manager**:
 
 > [!NOTE]
 > Node 2.0 mode disables or simplifies options that cannot be reproduced by browser compositor capture.
-> Transparent background, padding, link visibility, selection scope, and node opacity are not available in Node 2.0 mode.
+> Padding, link visibility, selection scope, and node opacity are not available in Node 2.0 mode.
 
 - **Format**: PNG / WebP  
   - Workflow embedding is **PNG only**.
 - **Embed workflow**: include workflow JSON in PNG.
-- **Background**:
-  - Classic: UI / Transparent / Solid.
-  - Node 2.0: UI / Solid.
+- **Background**: UI / Transparent / Solid.
+  - In Node 2.0, Transparent reconstructs alpha from black and white compositor captures.
 - **Padding**: margin around the captured bounds (slider).
 - **Show links**: include node links in Classic/LiteGraph exports.
 - **Scope** (when nodes are selected):
@@ -53,7 +53,8 @@ Install via **ComfyUI Manager**:
 ## Notes
 - Classic export uses the legacy LiteGraph renderer.
 - Node 2.0 export uses Chromium browser compositor capture. The browser will ask you to share the current tab/window when exporting.
-- Node 2.0 cannot preserve transparent pixels, so transparent background is Classic-only.
+- Node 2.0 transparent tiled exports may take longer than UI or Solid exports.
+- Animated video, WebGL, or canvas content may produce transparency artifacts.
 - Some Classic-only controls are disabled in Node 2.0 mode because browser compositor capture cannot faithfully reproduce them.
 - Preview is a faster render path and may skip heavy things (like video thumbnails).
 - DOM-backed widgets are handled best-effort.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workflow-image-export"
 description = "A simple ComfyUI extension to export images of your workflows with embedded JSON data."
-version = "1.1.3"
+version = "1.2.0"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
## Summary

- bump the package version from 1.1.3 to 1.2.0
- update the README to document transparent backgrounds in Node 2.0
- note tiled capture performance and animated-content limitations without exposing implementation-heavy details
- remove stale statements that transparent export is Classic-only

## Why

Version 1.2.0 includes the Node 2.0 transparent background support merged in #37. The package metadata and user-facing documentation need to match the released behavior.

## Validation

- `pyproject.toml` parses with project version `1.2.0`
- `npm test` — 118/118 passing
- `git diff --check`
