### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workflow-image-export"
 description = "A simple ComfyUI extension to export images of your workflows with embedded JSON data."
-version = "1.2.1"
+version = "1.2.2"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
## Summary

- bump the package version from 1.2.1 to 1.2.2
- prepare a patch release containing the merged export-policy and rendering fixes from #40

## Validation

- parsed `pyproject.toml` with Python `tomllib`
- verified `project.version == "1.2.2"`
- `git diff --check`